### PR TITLE
Show Module/Collection in media title depending on type

### DIFF
--- a/src/scripts/modules/media/title/title-template.html
+++ b/src/scripts/modules/media/title/title-template.html
@@ -3,7 +3,7 @@
 
   <div class="info">
     {{#if authors.length}}
-      <span>Collection by:</span>
+      <span>{{#is type 'book'}}Collection{{else}}Module{{/is}} by:</span>
       <span class="collection-author">
         {{#each authors}}
           <a href="mailto:{{email}}?subject={{../encodedTitle}}">{{fullname}}</a>


### PR DESCRIPTION
Fixes #90 

As discussed, the media title is still displayed as normal, but `Collection by` is now correctly displayed as `Module by`.
