### PR TITLE
Fix Breadcrumbs

### DIFF
--- a/src/scripts/modules/search/results/breadcrumbs/breadcrumbs.coffee
+++ b/src/scripts/modules/search/results/breadcrumbs/breadcrumbs.coffee
@@ -17,7 +17,7 @@ define (require) ->
     "text": "Text"
   }
 
-  capitalize: (str) ->
+  capitalize = (str) ->
     return (str.split(' ').map (word) -> word[0].toUpperCase() + word[1..-1].toLowerCase()).join ' '
 
   return class SearchResultsBreadcrumbsView extends BaseView

--- a/src/scripts/modules/search/results/filter/filter.coffee
+++ b/src/scripts/modules/search/results/filter/filter.coffee
@@ -12,7 +12,7 @@ define (require) ->
     "subject": "Subject"
   }
 
-  capitalize: (str) ->
+  capitalize = (str) ->
     return (str.split(' ').map (word) -> word[0].toUpperCase() + word[1..-1].toLowerCase()).join ' '
 
   return class SearchResultsFilterView extends BaseView


### PR DESCRIPTION
Add missing query name `title` and ensure a query name is always displayed.

Fixes #171 
