### PR TITLE
Upgrade to LESS 1.5.0

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -15,8 +15,8 @@
     "requirejs": "~2.1.9",
     "requirejs-text": "~2.0.10",
     "require-cs": "~0.4.4",
-    "require-css": "~0.0.8",
-    "require-less": "~0.0.8",
+    "require-css": "~0.1.0",
+    "require-less": "~0.1.0",
     "require-handlebars-plugin": "a9819e78f54dd5655b18dea976a2507baf660e1c"
   },
   "devDependencies": {


### PR DESCRIPTION
This also fixes a long running issue where the development version of webview would not load in Firefox due to an incompatibility between LESS 1.4.x and Firefox.
