### PR TITLE
Improve search result styling

### DIFF
--- a/src/scripts/modules/search/results/results.less
+++ b/src/scripts/modules/search/results/results.less
@@ -12,8 +12,13 @@
     .info {
       .make-xs-column(9);
 
-      tbody {
-        word-break: break-all;
+      table {
+        table-layout: fixed;
+        overflow: hidden;
+
+        tbody {
+          word-wrap: break-word;
+        }
       }
     }
   }


### PR DESCRIPTION
Use word-wrap and table-layout:fixed, rather than word-break , to more cleanly break long strings.
