### PR TITLE
Fix the dimensions of the connexions logo

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -28,7 +28,7 @@
     <noscript>
       <div class="noscript-container">
         <div class="noscript">
-          <img src="images/logo.png" width="238" height="60" alt="CNX" />
+          <img src="images/logo.png" width="300" height="106" alt="Connexions" />
           <p>This site requires JavaScript.</p>
           <small>Or you can view the legacy site at <a href="http://cnx.org/content">cnx.org/content</a></small>
         </div>

--- a/src/test/index.html
+++ b/src/test/index.html
@@ -28,7 +28,7 @@
     <noscript>
       <div class="noscript-container">
         <div class="noscript">
-          <img src="images/logo.png" width="238" height="60" alt="CNX" />
+          <img src="images/logo.png" width="300" height="106" alt="Connexions" />
           <p>This site requires JavaScript.</p>
           <small>Or you can view the legacy site at <a href="http://cnx.org/content">cnx.org/content</a></small>
         </div>


### PR DESCRIPTION
Dimensions of the logo in `noscript` was never updated when the logo changed.
