### PR TITLE
Notify user when they are entering the legacy site

### DIFF
--- a/src/scripts/loader.coffee
+++ b/src/scripts/loader.coffee
@@ -29,7 +29,13 @@ define (require) ->
 
       if external.test(href)
         if /^((f|ht)tps?:)?\/\/(\w*\.?)cnx\.org/.test(href)
-          location.href = href
+          if document.cookie.indexOf('legacy') >= 0
+            location.href = href
+
+          # Going to the legacy site
+          else if confirm('You are now entering the legacy site. To return, use your browser\'s back button.')
+            document.cookie = "legacy; max-age=#{60*60*24*30*365*4}; path=/;"
+            location.href = href
         else
           window.open(href, '_blank')
       else if resources.test(href)


### PR DESCRIPTION
Open an confirmation dialog warning a user they are entering the legacy site and that they can return to the new site using their browser's back button.

Stores a cookie on the person's computer after warning them once, and will not warn additional times thereafter unless they delete the cookie.

The issue originally asked for a checkbox to confirm whether or not to warn in the future; however, alert dialogues do not support checkboxes, so this simply sets the cookie every time.  Because all links are being overridden, it would be possible to create a custom Bootstrap modal dialogue for this purpose if desired, although it would be more work to do so.
