### PR TITLE
Include version numbers in ToC links

### DIFF
--- a/src/scripts/modules/media/tabs/contents/leaf.coffee
+++ b/src/scripts/modules/media/tabs/contents/leaf.coffee
@@ -8,6 +8,13 @@ define (require) ->
 
   return class TocNodeView extends BaseView
     template: template
+    templateHelpers: () ->
+      book = @model.get('book').toJSON()
+      # Ensure the version number is appended to the book id
+      if book.id.indexOf('@') is -1
+        book.id = "#{book.id}@#{book.version}"
+      return {book: book}
+
     tagName: 'li'
     itemViewContainer: '.subcollection'
 


### PR DESCRIPTION
Version numbers are not returned by cnx-archive, so they can't be added to search results.
