### PR TITLE
only add ui-has-child-title when there really is a title

### DIFF
--- a/src/scripts/models/contents/page.coffee
+++ b/src/scripts/models/contents/page.coffee
@@ -29,7 +29,8 @@ define (require) ->
         $title = $el.children('.title')
         $title.wrap('<header>')
         # Add a class for styling since CSS does not support `:has(> .title)`
-        $el.toggleClass('ui-has-child-title', $title.length)
+        # NOTE: `.toggleClass()` explicitly requires a `false` (not falsy) 2nd argument
+        $el.toggleClass('ui-has-child-title', $title.length > 0)
 
 
       # Wrap solutions in a div so "Show/Hide Solutions" work


### PR DESCRIPTION
`.toggleClass()` explicitly requires a `false` (not falsy) 2nd argument.

Without the `ui-has-child-title` class the `padding-right` should show up for untitled exercises/examples
