### PR TITLE
fix exercise title padding when default label is used

### DIFF
--- a/src/scripts/modules/media/body/body.less
+++ b/src/scripts/modules/media/body/body.less
@@ -427,31 +427,31 @@
   .make-block(@type) {
     #blockish>.style(@type);
 
-    // Style the label (using the default if none is provided)
+    // Use the default label if none is provided
     &:not([data-label])::before { #blockish>.default-label(@type); }
     // Use the data-label if one is provided
     &[data-label]:not([data-label=''])::before       { content: attr(data-label); }
+
+    // Style the label (depending on if there is a title)
+    &.ui-has-child-title::before         { #blockish>.label(@type; true); }
+    &:not(.ui-has-child-title)::before   { #blockish>.label(@type; false); }
+
+    // Style the title (if one exists) based on if there is a label
+    // NOTE: If there is no `data-label` then there **is** a default label.
+    &:not([data-label]),
+    &[data-label]:not([data-label='']) { > header > .title { #blockish>.title(@type; true); } }
+    &[data-label='']                     > header > .title { #blockish>.title(@type; false); }
     // Put a colon between the label and title if there is a non-empty label and a title.
     &:not([data-label='']) > header > .title::before {
       content: ': ';
     }
 
-    // Style the title (if one exists)
-    &.ui-has-child-title::before         { #blockish>.label(@type; true); }
-    &:not(.ui-has-child-title)::before   { #blockish>.label(@type; false); }
-    &[data-label]:not([data-label]='') > header {
-      display: inline-block; // So the label can slide in on the left
-      > .title { #blockish>.title(@type; true); }
-    }
-    &:not([data-label]),
-    &[data-label=''] {
-      > header {
-        display: inline-block; // So the label can slide in on the left
-        > .title { #blockish>.title(@type; false); }
-      }
-    }
+    > header { display: inline-block; } // So the label can slide in on the left
+
+    // Style the Body
     > section         { #blockish>.body(@type); }
   }
+
 
   .note     { .make-block(note); }
   .example  { .make-block(example); }


### PR DESCRIPTION
Small tweak.

Also, to enumerate the various cases this code block uses:

A Note without a title:
- `:not([data-label])` yields "Note"
- `[data-label='']`    yields ""
- `[data-label!='']`   yields "Custom"

A note with a title (uses `.ui-has-child-title`):
- `:not([data-label])` yields "Note: Title"
- `[data-label='']`    yields "Title"
- `[data-label!='']`   yields "Custom: Title"

Also, both the label and title need to be styled differently depend on the
  presence of the other (hence the `@has-title` and `@has-label` mixin params).
