### PR TITLE
Prevent long lists from overflowing

### DIFF
--- a/src/scripts/modules/media/body/body.less
+++ b/src/scripts/modules/media/body/body.less
@@ -136,6 +136,8 @@
 
   // A list with a title
   .list {
+    overflow-wrap: break-word;
+
     > .title {
       font-weight: bold;
     }


### PR DESCRIPTION
Prevents a list from overflowing out of its content box, such as on http://cnx.org/contents/30189442-6998-4686-ac05-ed152b91b9de@16.2:8
