### PR TITLE
Correctly display 'language' breadcrumb

### DIFF
--- a/src/scripts/models/search-results.coffee
+++ b/src/scripts/models/search-results.coffee
@@ -8,6 +8,7 @@ define (require) ->
     "author": "Author"
     "authorID": "Author"
     "keyword": "Keyword"
+    "language": "Language"
     "mediaType": "Type"
     "type": "Type"
     "pubYear": "Publication Date"

--- a/src/scripts/modules/search/advanced/advanced-template.html
+++ b/src/scripts/modules/search/advanced/advanced-template.html
@@ -67,15 +67,15 @@
         <div class="col-sm-10">
           <select name="language" class="form-control">
             <option value="">Any</option>
-            {{#each languages}}
+            {{~#each languages~}}
               <option value="{{@key}}">
-                {{#is native english}}
+                {{~#is native english~}}
                   {{native}}
-                {{else}}
+                {{~else~}}
                   {{native}} ({{english}})
-                {{/is}}
+                {{~/is~}}
               </option>
-            {{/each}}
+            {{~/each~}}
           </select>
         </div>
       </label>
@@ -87,9 +87,9 @@
         <div class="col-sm-10">
           <select name="pubYear" class="form-control">
             <option value="">Any</option>
-            {{#each years}}
+            {{~#each years~}}
               <option>{{this}}</option>
-            {{/each}}
+            {{~/each~}}
           </select>
         </div>
       </label>

--- a/src/scripts/modules/search/results/breadcrumbs/breadcrumbs-template.html
+++ b/src/scripts/modules/search/results/breadcrumbs/breadcrumbs-template.html
@@ -5,11 +5,11 @@
     </div>
     <span class="limit">{{this.name}}</span>
     <span class="value">
-      {{#if this.displayValue}}
+      {{~#if this.displayValue~}}
         {{this.displayValue}}
-      {{else}}
+      {{~else~}}
         {{this.value}}
-      {{/if}}
+      {{~/if~}}
     </span>
   </span>
 {{/each}}


### PR DESCRIPTION
Also remove whitespace from templates now that we are supporting a version of Handlebars that can do so for us.
