### PR TITLE
Explicitly use components/jquery to install jquery

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -7,7 +7,7 @@
     "node_modules"
   ],
   "dependencies": {
-    "jquery": "~2.1.0",
+    "jquery": "components/jquery#2.1.0",
     "lodash": "~2.4.1",
     "backbone": "~1.1.0",
     "backbone-associations": "~0.5.5",


### PR DESCRIPTION
`jquery` used to be a shorthand to `components/jquery`, while `jQuery` referred to `jquery/jquery`.
Recently the jQuery team requested that `jquery` point to `jquery/jquery` as well.
Bugs are now open with both projects:
http://bugs.jquery.com/ticket/14798
https://github.com/bower/bower/issues/1118

Until this issue is resolved, we should be explicit about what version we want.
