### PR TITLE
remove header element to match canonical HTML closer

### DIFF
--- a/src/scripts/models/contents/page.coffee
+++ b/src/scripts/models/contents/page.coffee
@@ -29,7 +29,6 @@ define (require) ->
           return !$(node).hasClass('title')
         $contents.wrapAll('<section>')
         $title = $el.children('.title')
-        $title.wrap('<header>')
         # Add an attribute for the parents' `data-label`
         # since CSS does not support `parent(attr(data-label))`.
         # When the title exists, this attribute is added before it

--- a/src/scripts/modules/media/body/body.less
+++ b/src/scripts/modules/media/body/body.less
@@ -432,7 +432,7 @@
     // Add the label to the title element (if one exists) or to the blockish element
     .place-label(@type; @label-type) {
       // A title exists so style it and put the label in `.title::before`
-      &.ui-has-child-title > header > .title {
+      &.ui-has-child-title > .title {
         #blockish>.title(@type);
         &::before { .format-label(@type; @label-type; true); }
       }


### PR DESCRIPTION
`note`, `example`, and `exercise` are affected by this but should behave the same since no styling was done on the `<header>` element directly.
