### PR TITLE
Weekly upgrades

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -10,7 +10,7 @@
     "jquery": "components/jquery#2.1.0",
     "lodash": "~2.4.1",
     "backbone": "~1.1.2",
-    "backbone-associations": "~0.6.0",
+    "backbone-associations": "~0.6.1",
     "bootstrap": "~3.1.1",
     "requirejs": "~2.1.11",
     "requirejs-text": "~2.0.10",


### PR DESCRIPTION
Upgrade require-handlebars-plugin to 0.8.0 (and handlebars to 1.3)
Use 0.6.0 release version of backbone-associations
Bump patches for Backbone (1.1.2) and RequireJS (2.1.11)
