### PR TITLE
Normalize comma-delimited list styling

### DIFF
--- a/src/scripts/modules/media/footer/metadata/metadata-template.html
+++ b/src/scripts/modules/media/footer/metadata/metadata-template.html
@@ -31,13 +31,17 @@
     <dd>
       <div>
         {{~#each model.subjects~}}
-          <span class="name">{{this}}</span>
+          <span class="list-comma">{{this}}</span>
         {{~/each~}}
       </div>
     </dd>
   <dt>Keywords:</dt>
     <dd>
-      <div>{{model.keywords}}</div>
+      <div>
+        {{~#each model.keywords~}}
+          <span class="list-comma">{{this}}</span>
+        {{~/each~}}
+      </div>
     </dd>
   <dt>License:</dt>
     <dd>
@@ -51,7 +55,7 @@
     <dd>
       <div>
         {{~#each model.authors~}}
-          <span class="name"><a href="mailto:{{email}}">{{fullname}}</a></span>
+          <a class="list-comma" href="mailto:{{email}}">{{fullname}}</a>
         {{~/each~}}
       </div>
     </dd>
@@ -59,7 +63,7 @@
     <dd>
       <div>
         {{#each model.licensors}}
-          <span class="name"><a href="mailto:{{email}}">{{fullname}}</a></span>
+          <a class="list-comma" href="mailto:{{email}}">{{fullname}}</a>
         {{/each}}
       </div>
     </dd>
@@ -67,7 +71,7 @@
     <dd>
       <div>
         {{#each model.maintainers}}
-          <span class="name"><a href="mailto:{{email}}">{{fullname}}</a></span>
+          <a class="list-comma" href="mailto:{{email}}">{{fullname}}</a>
         {{/each}}
       </div>
     </dd>

--- a/src/scripts/modules/media/footer/metadata/metadata.less
+++ b/src/scripts/modules/media/footer/metadata/metadata.less
@@ -27,10 +27,6 @@
         > ul {
           padding: 0 0 0 15px;
         }
-
-        > .name:not(:last-child)::after {
-          content: ", ";
-        }
       }
     }
   }

--- a/src/scripts/modules/media/header/header-template.html
+++ b/src/scripts/modules/media/header/header-template.html
@@ -7,7 +7,7 @@
           Derived from <a href="/contents/{{currentPage.parentId}}@{{currentPage.parentVersion}}">{{currentPage.parentTitle}}</a> by
           <span class="collection-authors">
             {{#each currentPage.parentAuthors}}
-              <a href="mailto:{{email}}?subject={{../encodedTitle}}">{{fullname}}</a>
+              <a class="list-comma" href="mailto:{{email}}?subject={{../encodedTitle}}">{{fullname}}</a>
             {{/each}}
           </span>
         </span>

--- a/src/scripts/modules/media/header/header.less
+++ b/src/scripts/modules/media/header/header.less
@@ -40,16 +40,6 @@
     .btn {
       margin: 0 0 20px auto;
     }
-
-    > .module-author a {
-      &::after {
-        content: ",";
-      }
-
-      &:last-of-type::after {
-        content: "";
-      }
-    }
   }
 
   > .summary {

--- a/src/scripts/modules/media/title/title-template.html
+++ b/src/scripts/modules/media/title/title-template.html
@@ -6,9 +6,9 @@
         <span>
           Derived from <a href="/contents/{{parentId}}@{{parentVersion}}">{{parentTitle}}</a> by
           <span class="collection-authors">
-            {{#each parentAuthors}}
-              <a href="mailto:{{email}}?subject={{../encodedTitle}}">{{fullname}}</a>
-            {{/each}}
+            {{~#each parentAuthors~}}
+              <a class="list-comma" href="mailto:{{email}}?subject={{../encodedTitle}}">{{fullname}}</a>
+            {{~/each~}}
           </span>
         </span>
       {{/if}}
@@ -18,9 +18,9 @@
       {{#if authors.length}}
         <span>{{#is type 'book'}}Collection{{else}}Module{{/is}} by:</span>
         <span class="collection-authors">
-          {{#each authors}}
-            <a href="mailto:{{email}}?subject={{../encodedTitle}}">{{fullname}}</a>
-          {{/each}}
+          {{~#each authors~}}
+            <a class="list-comma" href="mailto:{{email}}?subject={{../encodedTitle}}">{{fullname}}</a>
+          {{~/each~}}
           <img src="images/icons/mail.png" width="18" height="12" alt="Mail" />
         </span>
       {{/if}}

--- a/src/scripts/modules/media/title/title.less
+++ b/src/scripts/modules/media/title/title.less
@@ -5,16 +5,6 @@
   padding: 30px 30px 40px 30px;
   background-color: @gray-lightest;
 
-  .collection-authors a {
-    &::after {
-      content: ",";
-    }
-
-    &:last-of-type::after {
-      content: "";
-    }
-  }
-
   > .title {
     display: inline-block;
     margin-right: 7%;

--- a/src/styles/main.less
+++ b/src/styles/main.less
@@ -146,3 +146,11 @@ h5 {
   .social-button("images/social/pinterest.png");
   background-size: 50%;
 }
+
+//
+// Lists
+//
+
+.list-comma:not(:last-of-type)::after {
+  content: ", ";
+}


### PR DESCRIPTION
Fixes the spacing between keywords in metadata and normalizes the styling for all other lists that are displayed with a comma as the delimiter.
