### PR TITLE
EDITING: image upload

### DIFF
--- a/nginx.development.conf
+++ b/nginx.development.conf
@@ -9,7 +9,7 @@ http {
     listen 8000;
     root src;
     index index.html;
-    try_files $uri $uri/ /index.html;
+    try_files $uri /index.html;
 
     # Use cnx-authoring for login, workspace, POSTing contents and GETting drafts
     location /login {
@@ -45,7 +45,12 @@ http {
         proxy_pass http://archive.cnx.org;
     }
 
-    location /resources/ {
+    # This deals only with the route `/resources/` (nothing trailing)
+    location ~ ^/resources$ {
+        proxy_pass http://localhost:8080;
+    }
+
+    location ~ ^/resources/.+ {
         proxy_pass http://archive.cnx.org;
     }
 

--- a/src/scripts/configs/aloha.coffee
+++ b/src/scripts/configs/aloha.coffee
@@ -75,6 +75,14 @@ define ['jquery'], ($) ->
       ]
 
 
+      assorted:
+        image:
+          uploadSinglepart: false
+          parseresponse: false
+          uploadfield: 'file'
+          uploadurl: "#{location.origin}/resources"
+
+
       # This whole thing is what's needed to:
       #
       # - set a custom URL to send files to


### PR DESCRIPTION
this adds POSTing to `/resources` but does not rewrite the `<img src="...">` tags upon success.

The next PR will rewrite the URL after the POST using the URL from https://github.com/Connexions/cnx-authoring/pull/18 but any chance it could start with `/resources/` so I don't have to strip the protocol, host, and port when adding it to `<img src="..."/>`?

This is related to (but not dependent upon) https://github.com/Connexions/cnx-authoring/pull/19
