### PR TITLE
stop aloha caching content by using unique ids

### DIFF
--- a/src/scripts/configs/aloha.coffee
+++ b/src/scripts/configs/aloha.coffee
@@ -81,6 +81,9 @@ define ['jquery'], ($) ->
           uploadSinglepart: false
           # Use the body of the response as the URL
           parseresponse: (xhr) ->
+
+            setTimeout(window.GLOBAL_UPOADER_HACK, 100)
+
             return xhr.response
           # Send files using the `file` field when POSTing
           uploadfield: 'file'

--- a/src/scripts/helpers/backbone/views/editable.coffee
+++ b/src/scripts/helpers/backbone/views/editable.coffee
@@ -80,6 +80,7 @@ define (require) ->
 
             # Setup Aloha
             when 'aloha'
+
               # If this editable has an id, remove it so Aloha gives it a unique one
               # otherwise Aloha.getEditableById will return the previous (now detached)
               # DOM node if the page has re-rendered
@@ -108,6 +109,18 @@ define (require) ->
                     $alohaEditable = Aloha.jQuery($editable)
                     $alohaEditable.aloha()
 
+                    # Grab the editable so we can call `.getContents()`
+                    alohaId = $editable.attr('id')
+                    alohaEditable = Aloha.getEditableById(alohaId)
+
+
+                    if 'content' == value
+                      window.GLOBAL_UPOADER_HACK = () =>
+                        editableBody = alohaEditable.getContents()
+                        @model.set(value, editableBody)
+                        setChanged(options.onEdit)
+
+
                     # Update the model if an event for this editable was triggered
                     Aloha.bind 'aloha-smart-content-changed.updatemodel', (evt, d) =>
                       isItThisEditable = d.editable.obj.is($alohaEditable)
@@ -116,9 +129,6 @@ define (require) ->
                       if d.triggerType != 'blur' and isItThisEditable
 
                         # Update the model by retrieving the XHTML contents
-                        alohaId = $editable.attr('id')
-                        alohaEditable = Aloha.getEditableById(alohaId)
-
                         if alohaEditable
                           editableBody = alohaEditable.getContents()
                           editableBody = editableBody.trim() # Trim for idempotence


### PR DESCRIPTION
The previous "fix" did not work with nested editables (titles, note bodies, etc). If you changed the title of something then all the content would be replaced with just the title.
