### PR TITLE
EDITING: Move publishing mixin to mixins-app so it can utilize variables

### DIFF
--- a/src/styles/mixins-app.less
+++ b/src/styles/mixins-app.less
@@ -45,3 +45,11 @@
     }
   }
 }
+
+// Give elements that have a "publishing" status a green background color
+.publishing() {
+  &.publishing {
+    opacity: 0.7;
+    border-left: 2em solid @brand-info;
+  }
+}

--- a/src/styles/mixins.less
+++ b/src/styles/mixins.less
@@ -5,14 +5,3 @@
 .clearfix {
   .clearfix();
 }
-
-
-// Give elements that have a "publishing" status a green background color
-.publishing() {
-
-  &.publishing {
-    opacity: 0.7;
-    border-left: 2em solid @brand-info;
-  }
-
-}


### PR DESCRIPTION
App-specific mixins should be placed inside `mixins-app.less` rather than `mixins.less` so that they are always loaded after `variables.less` and can thus safely make use variables.
