### PR TITLE
EDITING: Ensure the Editor closes when its view is closed

### DIFF
--- a/src/scripts/modules/media/media.coffee
+++ b/src/scripts/modules/media/media.coffee
@@ -94,3 +94,5 @@ define (require) ->
       @regions.editbar.empty()
       $('body').css('padding-top', '0') # Remove added padding
       window.scrollBy(0, -height) # Prevent viewport from jumping
+
+    onBeforeClose: () -> @model.set('editable', false) if @model.get('editable')


### PR DESCRIPTION
This fixes the issue where padding added for the edit bar is not removed when navigating away from a page with the editor open.
