### PR TITLE
Add font-awesome

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -12,6 +12,7 @@
     "backbone": "~1.1.2",
     "backbone-associations": "~0.6.1",
     "bootstrap": "~3.1.1",
+    "font-awesome": "~4.1",
     "requirejs": "~2.1.11",
     "requirejs-text": "~2.0.10",
     "require-cs": "~0.4.4",

--- a/src/styles/main.less
+++ b/src/styles/main.less
@@ -1,4 +1,5 @@
 @import "/bower_components/bootstrap/less/bootstrap.less"; // Bootstrap
+@import "/bower_components/font-awesome/css/font-awesome.css"; // Bootstrap
 @import "./variables.less";
 @import "./mixins-app.less";
 


### PR DESCRIPTION
for all the icons used in Aloha (Off the top of my head: warning, link, edit, remove, settings, external-link, paragraph, image, table, certificate).

https://github.com/oerpub/Aloha-Editor/pull/150 has been upgraded to Font-Awesome 4.1 as well

glyphicon contains icons for warning, link, edit, remove, settings, image, table, certificate (missing paragraph, numbered-list, table)

Fixes #144
