### PR TITLE
Changed help link to point to zendesk

### DIFF
--- a/src/scripts/modules/header/header-template.html
+++ b/src/scripts/modules/header/header-template.html
@@ -13,7 +13,7 @@
         {{#if url}}
           <li><a href="{{url}}" title="Switch to the CNX legacy web site">Legacy Site</a></li>
         {{/if}}
-        <li><a href="http://cnx.org/help/">Help</a></li>
+        <li><a href="https://openstaxcnx.zendesk.com/hc/en-us">Help</a></li>
         <li><a href="http://cnx.org/aboutus/cnx_donate" class="btn">Donate</a></li>
       </ul>
     </div>


### PR DESCRIPTION
Zendesk is not public yet, but the link is correct.
