### PR TITLE
fix checkbox selection in tables

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -19,7 +19,7 @@
     "require-css": "~0.1.4",
     "require-less": "~0.1.2",
     "require-handlebars-plugin": "~0.8.1",
-    "aloha-editor": "oerpub/Aloha-Editor#34e5a13d6ae64878ffc2486611d14ba9dda98d65",
+    "aloha-editor": "oerpub/Aloha-Editor#9d1c9a68dece1e69034abe841cf57b96cfc64e33",
     "select2": "~3.4.8"
   },
   "devDependencies": {


### PR DESCRIPTION
Checkboxes in "Add Page" were not selectable because the Aloha table plugin was capturing events on _all_ tables on the page instead of just inside Aloha.

Related to https://github.com/oerpub/Aloha-Editor/pull/175
