### PR TITLE
Find the correct author by index

### DIFF
--- a/src/scripts/modules/search/results/breadcrumbs/breadcrumbs-template.html
+++ b/src/scripts/modules/search/results/breadcrumbs/breadcrumbs-template.html
@@ -6,7 +6,7 @@
     <span class="limit">{{name}}</span>
     <span class="value">
       {{~#is tag "authorID"~}}
-        {{author ../../authorList 0 'fullname'}} ({{author ../../authorList 0 'id'}})
+        {{author ../../authorList index 'fullname'}} ({{author ../../authorList index 'id'}})
       {{~else~}}
         {{value}}
       {{~/is~}}


### PR DESCRIPTION
Breadcrumbs were incorrectly assuming the author was always at index 0, which is no longer true since optimizing the JSON format.

Fixes: #676
