### PR TITLE
Prevent duplicate version numbers in content urls

### DIFF
--- a/src/scripts/modules/media/footer/attribution/attribution-template.html
+++ b/src/scripts/modules/media/footer/attribution/attribution-template.html
@@ -30,18 +30,18 @@
     <div class="citation">
       <span>{{#each authors}}<span class="name">{{fullname}}</span>{{/each}}, </span>
       <span>{{title}}. OpenStax CNX. </span>
-      <span>{{date revised}} http://cnx.org/contents/{{id}}@{{version}}.</span>
+      <span>{{date revised}} http://cnx.org/contents/{{id}}.</span>
     </div>
   </li>
   <li>
     If you redistribute this textbook in a print format,
     then you must include on every physical page the following attribution:<br />
-    "Download for free at http://cnx.org/contents/{{id}}@{{version}}."
+    "Download for free at http://cnx.org/contents/{{id}}."
   </li>
   <li>
     If you redistribute part of this textbook, then you must retain in every
     digital format page view (including but not limited to EPUB, PDF, and HTML)
     and on every physical printed page the following attribution:<br />
-    "Download for free at http://cnx.org/contents/{{id}}@{{version}}."
+    "Download for free at http://cnx.org/contents/{{id}}."
   </li>
 </ul>

--- a/src/scripts/modules/media/footer/attribution/attribution.coffee
+++ b/src/scripts/modules/media/footer/attribution/attribution.coffee
@@ -5,3 +5,5 @@ define (require) ->
 
   return class AttributionView extends FooterTabView
     template: template
+    templateHelpers:
+      id: () -> @model.getVersionedId() # Ensure the id has the version attached


### PR DESCRIPTION
Fixes #702 

Trello: https://trello.com/c/5ThwXvEb/982-1-webview-attribution-tab-has-version-duplicated-on-links
