### PR TITLE
Cleanup when and how canonical links are added

### DIFF
--- a/src/scripts/helpers/backbone/views/base.coffee
+++ b/src/scripts/helpers/backbone/views/base.coffee
@@ -62,15 +62,17 @@ define (require) ->
     initialize: () ->
       @regions = new Regions(@regions, @)
 
-
     renderDom: () ->
       @$el?.html(@getTemplate())
 
-    # Update page title
-    updateTitle: () ->
-      if @pageTitle
-        @addCanonicalMetaDataToDerivedCopies()
-        document.title = settings.titlePrefix + @pageTitle
+    # Update page title and canonical link
+    updatePageInfo: () ->
+      document.title = settings.titlePrefix + @pageTitle if @pageTitle
+
+      canonical = @canonical?() or @canonical
+      if canonical isnt undefined
+        $('link[rel="canonical"]').remove()
+        $('head').append("<link rel=\"canonical\" href=\"#{canonical}\" />") if canonical
 
     getTemplate: () -> @template?(@getTemplateData()) or @template
 
@@ -89,22 +91,9 @@ define (require) ->
 
       return data
 
-    addCanonicalMetaDataToDerivedCopies: () ->
-      # Remove canonical links to content
-      # FIX: This will trigger for every view. If the last view to load on the page does not have
-      #      a reference to the proper model, then the link will be removed even if it should be there.
-      #      This code should probably be changed to test if a specific setting is on a view and then
-      #      and only then add or remove the link as appropriate.
-      $("link[rel^=\"canonical\"]").remove()
-
-      parentId = @getTemplateData().parentId
-      if parentId
-        canonicalUrl = "<link rel=\"canonical\" href=\"//#{location.hostname}/contents/#{parentId}/\" />"
-        $('head').append(canonicalUrl)
-
     _render: () ->
       _.each @regions, (region) -> region.empty()
-      @updateTitle()
+      @updatePageInfo()
       @renderDom()
 
     render: () ->

--- a/src/scripts/modules/media/media.coffee
+++ b/src/scripts/modules/media/media.coffee
@@ -17,6 +17,13 @@ define (require) ->
   require('less!./media')
 
   return class MediaView extends BaseView
+    canonical: () ->
+      uuid = @model.getUuid()
+      if uuid
+        return "//#{location.host}/contents/#{uuid}/"
+      else
+        return null
+
     template: template
     regions:
       media: '.media'
@@ -32,7 +39,7 @@ define (require) ->
       @model = new Content({id: @uuid, version: options.version, page: options.page})
 
       @listenTo(@model, 'change:googleAnalytics', @trackAnalytics)
-      @listenTo(@model, 'change:title', @updateTitle)
+      @listenTo(@model, 'change:title change:parentId', @updatePageInfo)
       @listenTo(@model, 'change:legacy_id change:legacy_version change:currentPage pageLoaded', @updateLegacyLink)
       @listenTo(@model, 'change:error', @displayError)
       @listenTo(@model, 'change:editable', @toggleEditor)
@@ -68,7 +75,7 @@ define (require) ->
 
       $('html, body').animate({scrollTop: $mediaNav.offset().top}, '500', 'swing') if y > maxY
 
-    updateTitle: () ->
+    updatePageInfo: () ->
       @pageTitle = @model.get('title')
       super()
 

--- a/src/scripts/pages/about/about.coffee
+++ b/src/scripts/pages/about/about.coffee
@@ -14,6 +14,7 @@ define (require) ->
     templateHelpers:
       legacy: settings.legacy
     pageTitle: 'About OpenStax CNX'
+    canonical: null
 
     regions:
       find: '.find'

--- a/src/scripts/pages/contents/contents.coffee
+++ b/src/scripts/pages/contents/contents.coffee
@@ -14,6 +14,7 @@ define (require) ->
   return class ContentsPage extends BaseView
     template: template
     pageTitle: 'Content Library'
+    canonical: () -> null if not @uuid
 
     initialize: (options = {}) ->
       super()

--- a/src/scripts/pages/donate/donate.coffee
+++ b/src/scripts/pages/donate/donate.coffee
@@ -13,6 +13,7 @@ define (require) ->
   return class DonatePage extends BaseView
     template: template
     pageTitle: 'Support OpenStax CNX'
+    canonical: null
 
     regions:
       find: '.find'

--- a/src/scripts/pages/error/error.coffee
+++ b/src/scripts/pages/error/error.coffee
@@ -9,6 +9,7 @@ define (require) ->
   return class ErrorPage extends BaseView
     template: template
     templateHelpers: () -> {error: @error}
+    canonical: null
 
     regions:
       find: '#find-content'

--- a/src/scripts/pages/home/home.coffee
+++ b/src/scripts/pages/home/home.coffee
@@ -11,6 +11,7 @@ define (require) ->
   return class HomePage extends BaseView
     template: template
     pageTitle: 'Sharing Knowledge and Building Communities'
+    canonical: null
 
     regions:
       splash: '#splash'

--- a/src/scripts/pages/search/search.coffee
+++ b/src/scripts/pages/search/search.coffee
@@ -9,6 +9,7 @@ define (require) ->
 
   return class SearchPage extends BaseView
     template: template
+    canonical: null
 
     initialize: () ->
       super()

--- a/src/scripts/pages/workspace/workspace.coffee
+++ b/src/scripts/pages/workspace/workspace.coffee
@@ -9,6 +9,7 @@ define (require) ->
   return class WorkspacePage extends BaseView
     template: template
     pageTitle: 'My Workspace'
+    canonical: null
 
     regions:
       workspace: '#workspace'


### PR DESCRIPTION
Fixes #689 

Any view with a `canonical` property attached to it will cause
the canonical link tag in `<head>` to be updated, unless it
is explicitly set to `undefined`.

The value of `canonical` should be the link it should point to,
or a falsey value (like null) if it should not have a
canonical link.

This PR also changes the logic of when to apply canonical links
to content. Rather than attaching it to all derived copies,
which could differ substantially from their original, it attaches
the link to all content and makes it point to the unversioned URL
for the content. This ensures that every version of a piece of
content always shares the exact same URL, which seems to be a
more appropriate use of the tag.
