### PR TITLE
Properly initialize the role acceptances model

### DIFF
--- a/src/scripts/models/role-acceptances.coffee
+++ b/src/scripts/models/role-acceptances.coffee
@@ -6,10 +6,10 @@ define (require) ->
   AUTHORING = "#{location.protocol}//#{settings.cnxauthoring.host}:#{settings.cnxauthoring.port}"
 
   return class RoleAcceptance extends Backbone.Model
-    id = window.location.pathname.match(/\/[^\/]+$/)
-    url: "#{AUTHORING}/contents#{id}@draft/acceptance"
+    url: () -> "#{AUTHORING}/contents/#{@contentId}@draft/acceptance"
 
-    initialize: () =>
+    initialize: (options) =>
+      @contentId = options.id
       @fetch
         reset: true,
         xhrFields: withCredentials: true

--- a/src/scripts/modules/role-acceptances/role-acceptances.coffee
+++ b/src/scripts/modules/role-acceptances/role-acceptances.coffee
@@ -22,7 +22,8 @@ define (require) ->
       'click .reject': 'rejectRole'
 
     initialize: () ->
-      @model = new RoleAcceptances()
+      id = location.pathname.replace('/users/role-acceptance/', '')
+      @model = new RoleAcceptances({id: id})
       @listenTo(@model, 'change:roles', @render)
 
     acceptRole: (e) ->

--- a/src/scripts/pages/role-acceptance/role-acceptance.coffee
+++ b/src/scripts/pages/role-acceptance/role-acceptance.coffee
@@ -5,7 +5,6 @@ define (require) ->
   FindContentView = require('cs!modules/find-content/find-content')
   template = require('hbs!./role-acceptance-template')
   RoleAcceptancesView = require('cs!modules/role-acceptances/role-acceptances')
-
   require('less!./role-acceptance')
 
   return class RoleAcceptance extends BaseView


### PR DESCRIPTION
The role acceptances model was using the syntax `id =` in
the class itself, which when compiled to JavaScript meant
the id was being stored on the class object, not
on instances of it. Therefore, the `id` would only ever
be set once.

Also, moved the code that determined the `id` from the model to
the view, since the model should not be cognizant of nor care
about the url.

Fixes #821 
