### PR TITLE
Fix issue where page title was undefined

### DIFF
--- a/src/scripts/modules/media/header/header.coffee
+++ b/src/scripts/modules/media/header/header.coffee
@@ -16,10 +16,10 @@ define (require) ->
       currentPage = @getModel()
 
       if currentPage
-        currentPageData = currentPage.toJSON()
-        currentPageData.encodedTitle = encodeURI(currentPage.title)
+        currentPage = currentPage.toJSON()
+        currentPage.encodedTitle = encodeURI(currentPage.title)
       else
-        currentPageData = {
+        currentPage = {
           title: 'Untitled'
           encodedTitle: 'Untitled'
           authors: []
@@ -29,7 +29,7 @@ define (require) ->
       pageDownloads = currentPage?.get?('downloads')
 
       return {
-        currentPage: currentPageData
+        currentPage: currentPage
         hasDownloads: (_.isArray(downloads) and downloads?.length) or
           (_.isArray(pageDownloads) and pageDownloads?.length)
         derivable: @isDerivable()


### PR DESCRIPTION
`currentPageData.encodedTitle = encodeURI(currentPage.title)` was always setting the `encodedTitle` to undefined, because `currentPage` was set to `@model`, while `currentPageData` was the `toJSON` version of the content.  `@model` never had a `title` property attached to it (it would be in `@model.attributes.title` or accessible with `@model.get('title')`).