### PR TITLE
Fix for scrolling in modules

### DIFF
--- a/src/scripts/modules/media/editbar/modals/list/section.coffee
+++ b/src/scripts/modules/media/editbar/modals/list/section.coffee
@@ -17,9 +17,7 @@ define (require) ->
         container: @itemViewContainer
 
       super()
-      @listenTo(@model, 'change:unit', @render)
-      @listenTo(@model.get('contents'), 'change:title', @render)
-      @listenTo(@model.get('contents'), 'add:contents', @render)
+      @listenTo(@model, 'change:unit change:changed', @render)
 
     onRender: () ->
       super()


### PR DESCRIPTION
Instead of proxying change event for title, the code is listening for change:changed so the view is rendered when a title or content is changed within a section.

Fixes https://github.com/Connexions/webview/issues/950
Fixes https://github.com/Connexions/webview/issues/947