### PR TITLE
Role acceptance link only displayed when needed

### DIFF
--- a/src/scripts/modules/workspace/results/list/workspace-item-partial.html
+++ b/src/scripts/modules/workspace/results/list/workspace-item-partial.html
@@ -14,10 +14,10 @@
     <h4><a href="/contents/{{id}}/{{trim title}}">{{title}}</a></h4>
   </td>
   <td class="status">
-    {{#is state 'Draft'}}
-      <h4><a href="/contents/{{id}}/{{trim title}}">{{state}}</a></h4>
-    {{else}}
+    {{#is state 'Awaiting acceptance'}}
       <h4><a href="/users/role-acceptance/{{noVersion id}}">{{state}}</a></h4>
+    {{else}}
+      <h4><a href="/contents/{{id}}/{{trim title}}">{{state}}</a></h4>
     {{/is}}
   </td>
   <td class="edited">{{date revised}}</td>


### PR DESCRIPTION
Small change that fixes status link. It was pointing to role acceptance for every state except Draft.  It is now pointing to the content for every state except "Awaiting acceptance'.