### PR TITLE
Allow placing cursor at the end of content

### DIFF
--- a/src/scripts/helpers/backbone/views/editable.coffee
+++ b/src/scripts/helpers/backbone/views/editable.coffee
@@ -91,10 +91,18 @@ define (require) ->
           $editable.text('Starting up Aloha...')
           # Wait for Aloha to start up
           Aloha.ready () =>
-            html = @getProperty(property) or '<p> </p>' # Allow putting cursor after a Blockish. removed if empty.
+            html = @getProperty(property) or ''
+
+            if $editable.hasClass('draft')
+              html += '<p> </p>' # Allow putting cursor after a Blockish. removed if empty.
 
             $editable.html(html)
             $editable.addClass('aloha-root-editable') # the semanticblockplugin needs this for some reason
+
+              #$this = $editable
+              #if $this.last() isnt $('<p> &nbsp;</p>')
+              #  $this.append('<p>&nbsp;</p>')
+
             # Unwrap <section> elements into h# elements
             # There are 3 cases:
             # 1. <section><h#>

--- a/src/scripts/helpers/backbone/views/editable.coffee
+++ b/src/scripts/helpers/backbone/views/editable.coffee
@@ -94,7 +94,7 @@ define (require) ->
             html = @getProperty(property) or ''
 
             if $editable.hasClass('draft')
-              html += '<p> </p>' # Allow putting cursor after a Blockish. removed if empty.
+              html += '<p> &nbsp;</p>' # Allow putting cursor after a Blockish. removed if empty.
 
             $editable.html(html)
             $editable.addClass('aloha-root-editable') # the semanticblockplugin needs this for some reason


### PR DESCRIPTION
@edwoodward  found a problem with placing his cursor at the end of this content /contents/6adb2f84-9885-4207-bf83-563a511d6acd@3/What_Is_Sociology

This legacy content did not have a p tag at the end, which is why he couldn't set his cursor after the content. The code in this PR adds the paragraph element to the end of the content only if it's a draft. @pumazi had created this issue https://github.com/Connexions/webview/issues/775 because empty p tags were being saved to the abstract. This is not happening anymore. 