### PR TITLE
Place cursor at the end of content

### DIFF
--- a/src/scripts/helpers/backbone/views/editable.coffee
+++ b/src/scripts/helpers/backbone/views/editable.coffee
@@ -91,7 +91,10 @@ define (require) ->
           $editable.text('Starting up Aloha...')
           # Wait for Aloha to start up
           Aloha.ready () =>
-            html = @getProperty(property) or '<p> </p>' # Allow putting cursor after a Blockish. removed if empty.
+            html = @getProperty(property) or ''
+
+            if $editable.hasClass('draft') and $editable.last() isnt $('<p></p>')
+              html += '<p></p>' # Allow putting cursor after a Blockish. removed if empty.
 
             $editable.html(html)
             $editable.addClass('aloha-root-editable') # the semanticblockplugin needs this for some reason

--- a/src/styles/main.less
+++ b/src/styles/main.less
@@ -263,3 +263,7 @@ select {
 .modal-open {
   padding-right: 0 !important;
 }
+
+p:empty {
+    height: 1px;
+}


### PR DESCRIPTION
@edwoodward found a problem with this content http://localhost:8000/contents/6adb2f84-9885-4207-bf83-563a511d6acd@3/What_Is_Sociology?? He could not add content to the end of the page because there is no p tag after the content. This PR adds the p tag to the end of the content if it doesn't exist.

@pumazi created this issue https://github.com/Connexions/webview/issues/775 because empty p tags were being added to the summary. This PR is only adding the empty p tag to the draft itself, not the summary.