### PR TITLE
Remove template helpers from attribution.coffee

### DIFF
--- a/src/scripts/modules/media/footer/attribution/attribution.coffee
+++ b/src/scripts/modules/media/footer/attribution/attribution.coffee
@@ -5,7 +5,3 @@ define (require) ->
 
   return class AttributionView extends FooterTabView
     template: template
-    templateHelpers: () ->
-      model = super()
-      model.id = @model.getVersionedId() # Ensure the id has the version attached
-      return model


### PR DESCRIPTION
We do not need to include a templateHelper in attribution.coffee for id. When toggling between book and page, the view is rendered and getVersionedId method is called, adding the version to the end of the id in the attribution links.

Fixes Ed's last comment in https://github.com/Connexions/webview/issues/1026