### PR TITLE
show only first item from exercises api, otherwise, show blank

### DIFF
--- a/src/scripts/modules/media/body/embeddables/exercise-template.html
+++ b/src/scripts/modules/media/body/embeddables/exercise-template.html
@@ -1,5 +1,5 @@
-{{#each data.items}}
-    {{#each this.questions}}
+{{#if data.items.[0].questions}}
+    {{#each data.items.0.questions}}
         {{{this.stem_html}}}
     {{/each}}
-{{/each}}
+{{/if}}


### PR DESCRIPTION
shows only first item from exercises, see openstax/tutor-server#246

if first item does not exist, show blank

tested manually with [a book](http://localhost:8000/contents/7db9aa72-f815-4c3b-9cb6-d50cf5318b58@4.128:2/Updated_Tutor_HS_Physics_Conte) on archive.cnx.org