### PR TITLE
Update dependencies on master

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -10,8 +10,8 @@
   ],
   "dependencies": {
     "jquery": "~2.1.1",
-    "lodash": "~3.8.0",
-    "backbone": "~1.1.2",
+    "underscore": "~1.8.3",
+    "backbone": "~1.2.0",
     "backbone-associations": "~0.6.1",
     "bootstrap": "~3.3.1",
     "font-awesome": "~4.3.0",
@@ -25,7 +25,7 @@
     "select2": "~3.5.1"
   },
   "devDependencies": {
-    "chai": "~2.3.0",
+    "chai": "~3.0.0",
     "mocha": "~2.2.4",
     "sinonjs": "~1.10.2"
   }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "url": "https://github.com/Connexions/webview.git"
   },
   "dependencies": {
-    "grunt": "~0.4.5"
+    "grunt": "~0.4.5",
+    "underscore": "^1.8.3"
   },
   "devDependencies": {
     "grunt-contrib-requirejs": "~0.4.4",

--- a/src/scripts/config.js
+++ b/src/scripts/config.js
@@ -10,7 +10,7 @@
 
       // ## Core Libraries
       jquery: '../../bower_components/jquery/dist/jquery',
-      underscore: '../../bower_components/lodash/lodash',
+      underscore: '../../bower_components/underscore/underscore',
       backbone: '../../bower_components/backbone/backbone',
       'hbs/handlebars': '../../bower_components/require-handlebars-plugin/hbs/handlebars',
 


### PR DESCRIPTION
This update switches back to using underscore rather than lodash. The latest version of lodash is not compatible with the latest version of Backbone. Underscore has made improvements.

Will need to run `bower uninstall lodash` to remove the dependency files from bower components.