### PR TITLE
Fixed off by 1 error in browser history

### DIFF
--- a/src/scripts/helpers/backbone/views/base.coffee
+++ b/src/scripts/helpers/backbone/views/base.coffee
@@ -68,7 +68,16 @@ define (require) ->
 
     # Update page title, canonical link and Open Graph tags
     updatePageInfo: () ->
-      document.title = @pageTitle + settings.titleSuffix if @pageTitle
+      # If this is a page in a book/collection
+      if @pageTitle and @model? and @model.get('currentPage') and @model.get('currentPage')? and linksHelper.getCurrentPathComponents().page?
+        #alert(@model.getPageNumber() + ' vs: ' + linksHelper.getCurrentPathComponents().page)
+        # Only update title if the new one belongs to the current page
+        if @model.getPageNumber().toString() is linksHelper.getCurrentPathComponents().page
+          #alert('yo')
+          document.title = @pageTitle + settings.titleSuffix if @pageTitle
+      # Just update the title if it's a standalone page
+      else
+        document.title = @pageTitle + settings.titleSuffix if @pageTitle
 
       canonical = @canonical?() or @canonical
       if canonical isnt undefined

--- a/src/scripts/helpers/backbone/views/base.coffee
+++ b/src/scripts/helpers/backbone/views/base.coffee
@@ -68,16 +68,17 @@ define (require) ->
 
     # Update page title, canonical link and Open Graph tags
     updatePageInfo: () ->
-      # If this is a page in a book/collection
-      if @model? and linksHelper.getCurrentPathComponents().page?
-        # Only update title if the new one belongs to the current page
-        if @model.getPageNumber().toString() is linksHelper.getCurrentPathComponents().page
-          document.title = @pageTitle + settings.titleSuffix if @pageTitle
-        if @model.getPageNumber().toString() is '1' and linksHelper.getCurrentPathComponents().page is ''
-          document.title = @pageTitle + settings.titleSuffix if @pageTitle
-      # Just update the title if it's a standalone page
-      else
-        document.title = @pageTitle + settings.titleSuffix if @pageTitle
+      if @pageTitle
+        # If this is a page in a book/collection
+        if @model? and linksHelper.getCurrentPathComponents().page?
+          # Only update title if the new one belongs to the current page
+          if @model.getPageNumber().toString() is linksHelper.getCurrentPathComponents().page
+            document.title = @pageTitle + settings.titleSuffix
+          if @model.getPageNumber().toString() is '1' and linksHelper.getCurrentPathComponents().page is ''
+            document.title = @pageTitle + settings.titleSuffix
+        # Just update the title if it's a standalone page
+        else
+          document.title = @pageTitle + settings.titleSuffix
 
       canonical = @canonical?() or @canonical
       if canonical isnt undefined

--- a/src/scripts/helpers/backbone/views/base.coffee
+++ b/src/scripts/helpers/backbone/views/base.coffee
@@ -69,11 +69,11 @@ define (require) ->
     # Update page title, canonical link and Open Graph tags
     updatePageInfo: () ->
       # If this is a page in a book/collection
-      if @pageTitle and @model? and @model.get('currentPage') and @model.get('currentPage')? and linksHelper.getCurrentPathComponents().page?
-        #alert(@model.getPageNumber() + ' vs: ' + linksHelper.getCurrentPathComponents().page)
+      if @pageTitle and @model? and linksHelper.getCurrentPathComponents().page?
         # Only update title if the new one belongs to the current page
         if @model.getPageNumber().toString() is linksHelper.getCurrentPathComponents().page
-          #alert('yo')
+          document.title = @pageTitle + settings.titleSuffix if @pageTitle
+        if @model.getPageNumber().toString() is '1' and linksHelper.getCurrentPathComponents().page is ''
           document.title = @pageTitle + settings.titleSuffix if @pageTitle
       # Just update the title if it's a standalone page
       else

--- a/src/scripts/helpers/backbone/views/base.coffee
+++ b/src/scripts/helpers/backbone/views/base.coffee
@@ -69,7 +69,7 @@ define (require) ->
     # Update page title, canonical link and Open Graph tags
     updatePageInfo: () ->
       # If this is a page in a book/collection
-      if @pageTitle and @model? and linksHelper.getCurrentPathComponents().page?
+      if @model? and linksHelper.getCurrentPathComponents().page?
         # Only update title if the new one belongs to the current page
         if @model.getPageNumber().toString() is linksHelper.getCurrentPathComponents().page
           document.title = @pageTitle + settings.titleSuffix if @pageTitle


### PR DESCRIPTION
Previously, a view could have a title that aligned with the next page to be viewed, which would create a mismatch in browser history.  This code addresses that.