### PR TITLE
Improve Accessibility of Home Page

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en-US">
   <head>
     <title>OpenStax CNX</title>
     <meta charset="utf-8" />

--- a/src/scripts/loader.coffee
+++ b/src/scripts/loader.coffee
@@ -86,6 +86,7 @@ define (require) ->
 
     Backbone.history.start
       pushState: true
+      hashChange: false
       root: root
 
     # Force Backbone to register the full path including the query in its history

--- a/src/scripts/modules/featured-books/featured-books-partial.html
+++ b/src/scripts/modules/featured-books/featured-books-partial.html
@@ -1,6 +1,6 @@
 <div class="book">
-  <a href="{{link}}"><img src="{{cover}}" width="125" height="162" alt="{{title}}" /></a>
-  <h4 id="fb-{{id}}-title"><a href="{{link}}">{{title}}</a></h4>
+  <a href="{{link}}" tabindex="-1"><img src="{{cover}}" width="125" height="162" alt="{{title}}" /></a>
+  <h4 id="fb-{{prefix}}-{{id}}-title"><a href="{{link}}">{{title}}</a></h4>
   <p>{{description}}</p>
-  <div class="read-more"><a href="{{link}}" aria-labelledby="fb-{{id}}-title">Read More</a></div>
+  <div class="read-more"><a href="{{link}}" aria-labelledby="fb-{{prefix}}-{{id}}-title">Read More</a></div>
 </div>

--- a/src/scripts/modules/featured-books/featured-books-template.html
+++ b/src/scripts/modules/featured-books/featured-books-template.html
@@ -1,7 +1,7 @@
-<div id="featured-books" class="featured-books carousel">
+<div class="featured-books carousel">
   <div class="books">
     {{#each this}}
-      {{> modules/featured-books/featured-books-partial}}
+      {{> modules/featured-books/featured-books-partial prefix='car'}}
     {{/each}}
   </div>
 </div>
@@ -11,7 +11,7 @@
   <div class="books">
   {{#each this}}
     {{#is type 'OpenStax Featured'}}
-      {{> modules/featured-books/featured-books-partial}}
+      {{> modules/featured-books/featured-books-partial prefix='stax'}}
     {{/is}}
   {{/each}}
   </div>
@@ -22,7 +22,7 @@
   <div class="books">
   {{#each this}}
     {{#is type 'CNX Featured'}}
-      {{> modules/featured-books/featured-books-partial}}
+      {{> modules/featured-books/featured-books-partial prefix='cnx'}}
     {{/is}}
   {{/each}}
   </div>

--- a/src/scripts/modules/find-content/find-content.less
+++ b/src/scripts/modules/find-content/find-content.less
@@ -69,7 +69,7 @@
 
     &:focus {
       border: 1px solid transparent;
-      box-shadow: none;
+      box-shadow: 0 0 3pt 1pt rgb(0, 0, 0);
     }
 
     @media screen and (max-width: @screen-xs-max) {
@@ -98,6 +98,10 @@
     > .dropdown-toggle {
       outline: none;
       background: transparent url(/images/icons/arrows-white.png) no-repeat 98% center;
+      
+      &:focus {
+        box-shadow: 0 0 3pt 1pt rgb(0, 0, 0);
+      }
     }
 
     > .dropdown-menu {

--- a/src/scripts/modules/header/header-template.html
+++ b/src/scripts/modules/header/header-template.html
@@ -3,6 +3,9 @@
     {{! Site Status View }}
   </div>
   <div class="login">
+    <div id="skiptocontent">
+      <a href="#main">skip to main content</a>
+    </div>
     <ul>
       {{#if username}}
         <li><a data-bypass="true" href="{{accountProfile}}">Account Profile</a></li>

--- a/src/scripts/modules/header/header.coffee
+++ b/src/scripts/modules/header/header.coffee
@@ -18,6 +18,9 @@ define (require) ->
       accountProfile: settings.accountProfile
     }
 
+    events:
+      'click #skiptocontent a': 'skipToContent'
+
     initialize: (options = {}) ->
       super()
       @page = options.page
@@ -30,6 +33,23 @@ define (require) ->
 
     onRender: () ->
       @regions.siteStatus.show(new SiteStatusView())
+
+    skipToContent: (e) ->
+      el = document.getElementById('main')
+
+      if el
+        if !/^(?:a|select|input|button|textarea)$/i.test(el.tagName)
+          el.tabIndex = -1
+
+          removeTabIndex = () ->
+            this.removeAttribute('tabindex')
+            this.removeEventListener('blur', removeTabIndex, false)
+            this.removeEventListener('focusout', removeTabIndex, false)
+
+          el.addEventListener('blur', removeTabIndex, false)
+          el.addEventListener('focusout', removeTabIndex, false)
+
+        el.focus()
 
     setLegacyLink: (url) ->
       if url

--- a/src/scripts/modules/header/header.less
+++ b/src/scripts/modules/header/header.less
@@ -19,6 +19,26 @@
     font-weight: 300;
     text-align: right;
 
+    > #skiptocontent {
+      a {
+        position: absolute;
+        left: -20rem;
+
+        &:focus {
+            left: 0;
+            top: 0;
+            padding: 0.5rem 1rem;
+            font-size: 1.8rem;
+            color: white;
+            background: @brand-secondary;
+            outline: 0;
+            border-bottom-right-radius: 1rem;
+            -webkit-transition: top .1s ease-in, background .5s linear;
+            transition: top .1s ease-in, background .5s linear;
+        }
+      }
+    }
+
     > ul {
       padding: 0;
       list-style-type: none;


### PR DESCRIPTION
- [x] Add language attribute to html tag
- [x] Provide visual feedback when elements are tab-selected
- [x] Disable tabbing to superfluous links
- [x] Add hidden 'Skip to Content' button at top of page (accessible on first tab)
- [x] Remove duplicate IDs on elements

Issues remaining:
 - Zendesk has some accessibility issues that can't be fixed
 - Carousels in general are very unfriendly, especially to users with greater accessibility needs