### PR TITLE
Disable tabbing to superfluous image links

### DIFF
--- a/src/scripts/modules/browse-content/browse-content-template.html
+++ b/src/scripts/modules/browse-content/browse-content-template.html
@@ -14,7 +14,7 @@
         <h3>
           <a href="/search?q=subject:&quot;{{name}}&quot;">{{name}}</a>
         </h3>
-        <a href="/search?q=subject:&quot;{{name}}&quot;">
+        <a href="/search?q=subject:&quot;{{name}}&quot;" tabindex="-1">
           <img src="{{image}}" width="250" height="125" alt="{{name}}" />
         </a>
         <div class="data">


### PR DESCRIPTION
Simple change to the Contents Page (when browsing content) that simply disables tabbing to superfluous links.  Some overlapping issues were fixed in the previous PR for Home Page accessibility.