### PR TITLE
Enhance description meta tag

### DIFF
--- a/src/scripts/helpers/backbone/views/base.coffee
+++ b/src/scripts/helpers/backbone/views/base.coffee
@@ -107,7 +107,10 @@ define (require) ->
 
     addMetaTags: () ->
       summary = @summary?() or @summary
-      description = @description?() or @description
+      if typeof @description is 'function'
+        description = @description() or ''
+      else
+        description = @description
       location.origin = linksHelper.locationOrigin()
       head = $('head')
 
@@ -124,7 +127,7 @@ define (require) ->
         $('meta[property="og:image"]').remove()
         head.append("<meta property=\"og:image\" content=\"#{image}\">")
 
-      if description isnt undefined
+      if description isnt undefined and description isnt ''
         $('meta[name="description"]').remove()
         head.append("<meta name=\"description\" content=\"#{description}\">")
 

--- a/src/scripts/modules/media/media.coffee
+++ b/src/scripts/modules/media/media.coffee
@@ -31,7 +31,7 @@ define (require) ->
       editbar: '.editbar'
 
     summary:() -> @updateSummary()
-    description: () -> @updateSummary()
+    description: () -> @updateDescription()
 
     events:
       'keydown .media-title > .title input': 'checkKeySequence'
@@ -53,6 +53,7 @@ define (require) ->
       @listenTo(@model, 'change:error', @displayError)
       @listenTo(@model, 'change:editable', @toggleEditor)
       @listenTo(@model, 'change:title change:currentPage change:currentPage.loaded', @updateUrl)
+      @listenTo(@model, 'change:title change:currentPage change:currentPage.loaded', @updatePageInfo)
       @listenTo(@model, 'change:abstract', @updateSummary)
 
     onRender: () ->
@@ -73,6 +74,13 @@ define (require) ->
       else
         return 'An OpenStax CNX book'
 
+    updateDescription: () ->
+      if @model.get('currentPage')?.get('abstract')? and
+      @model.get('currentPage').get('abstract').replace(/(<([^>]+)>)/ig, "") isnt ''
+        # regular expression to strip tags
+        return @model.get('currentPage').get('abstract').replace(/(<([^>]+)>)/ig, "")
+      else
+        return @updateSummary()
 
     updateUrl: () ->
       components = linksHelper.getCurrentPathComponents()


### PR DESCRIPTION
The description meta tag is currently just the book summary.  With this change, when individual pages have their own abstract/summary, the description tag is set to this instead.  Otherwise, it remains the same as before.