### PR TITLE
Override Bootstrap caret rule so it shows in dist

### DIFF
--- a/src/styles/main.less
+++ b/src/styles/main.less
@@ -283,3 +283,8 @@ p:empty {
   background-color: #d9f3ce;
   color: #2a702b;
 }
+
+// Bootstrap Fixes
+.caret {
+  border-top: 4px solid !important;
+}


### PR DESCRIPTION
Bootstrap has the following 2 rules for `.caret`:
```
border-top: 4px dashed;
border-top: 4px solid \9;
```

Unfortunately, we're interpreting the 2nd rule as overriding the first when minimizing CSS (it's intended only as a fix for IE9).  Since we don't support IE9, this PR overrides those rules to ensure a valid `border-top` rule is used.