### PR TITLE
Add modal to dom only if os-interactive-link is present

### DIFF
--- a/src/scripts/modules/media/body/body.coffee
+++ b/src/scripts/modules/media/body/body.coffee
@@ -73,7 +73,7 @@ define (require) ->
       try
         if @model.get('loaded') and @model.asPage()?.get('loaded') and @model.asPage()?.get('active')
 
-          if $temp.find('.os-interactive-link')
+          if $temp.find('.os-interactive-link').length
             @model.set('sims', true)
 
           # Remove the module title and abstract TODO: check if it is still necessary


### PR DESCRIPTION
After reviewing an issue that @edwoodward found yesterday, it appears that the sims modal was appending to the dom no matter if the sims link was present or not. 

https://github.com/Connexions/webview/issues/1159

