### PR TITLE
Improve robustness of License module

### DIFF
--- a/src/scripts/modules/media/editbar/license/modals/license.coffee
+++ b/src/scripts/modules/media/editbar/license/modals/license.coffee
@@ -30,11 +30,20 @@ define (require) ->
     setLicense: () ->
       licenses = @collection.models
       selectedValue = @$el.find('input[name="licenses"]:checked').val()
-      selectedLicense = {}
-      _.each licenses, (license) ->
+      selectedLicense = _.find licenses, (license) ->
         versionedCode = "#{license.get('code')}-#{license.get('version')}"
         if versionedCode is selectedValue
-          selectedLicense = license
+          return license
+
+      if not selectedLicense
+        selectedLicense =
+          url: "http://cnx.org"
+          code: "unknown"
+          name: "Unknown License"
+          version: "0.1"
+          isValidForPublication: false
+        console.warn "No license found matching the selected value #{selectedValue} for #{@parent.model.get('id')}"
+
       return selectedLicense
 
     changeLicense: () ->

--- a/src/scripts/modules/media/editbar/license/modals/license.coffee
+++ b/src/scripts/modules/media/editbar/license/modals/license.coffee
@@ -30,7 +30,7 @@ define (require) ->
     setLicense: () ->
       licenses = @collection.models
       selectedValue = @$el.find('input[name="licenses"]:checked').val()
-      selectedLicense = ''
+      selectedLicense = {}
       _.each licenses, (license) ->
         versionedCode = "#{license.get('code')}-#{license.get('version')}"
         if versionedCode is selectedValue
@@ -58,7 +58,7 @@ define (require) ->
       @parent.model.set('licenseCode', @parent.model.get('license').code)
 
     selectedLicense: (model, selectedLicense) ->
-      model.code = selectedLicense.get('code')
-      model.name = selectedLicense.get('name')
-      model.url = selectedLicense.get('url')
-      model.version = selectedLicense.get('version')
+      model.code = selectedLicense.get?('code')
+      model.name = selectedLicense.get?('name')
+      model.url = selectedLicense.get?('url')
+      model.version = selectedLicense.get?('version')


### PR DESCRIPTION
 - Use `_.find` instead of `_.each` to match licenses faster
 - Improve robustness to prevent an unmatched license from crashing the app
 - Throw a warning when no license is matched to help with debugging