### PR TITLE
Prevent overriding styles in dist build

### DIFF
--- a/src/styles/main.less
+++ b/src/styles/main.less
@@ -146,7 +146,7 @@ h5 {
 
 .facebook {
   .social-button("/images/social/facebook.png");
-  background-size: 0.9rem 2rem;
+  background-size: 0.9rem 2rem !important;
 }
 
 .twitter {
@@ -155,14 +155,14 @@ h5 {
 
 .google {
   .social-button("/images/social/google.png");
-  background-position: 0 0.5rem;
-  background-size: 2.4rem 2.4rem;
+  background-position: 0 0.5rem !important;
+  background-size: 2.4rem 2.4rem !important;
 }
 
 .linkedin {
   .social-button("/images/social/linkedin.png");
-  background-size: 60%;
-  background-position: 50% 45%;
+  background-size: 60% !important;
+  background-position: 50% 45% !important;
 }
 
 //


### PR DESCRIPTION
The `.social-button` mixin defines defaults for `background-size` and `background-position`, which should be getting overridden by the new styles defined after them (and is appropriately overridden in dev).  However, in the dist version, the CSS compressor makes an unfortunate choice that causes the rules to appear in the wrong order.  Adding `!important` ensures they will still take precedence.