### PR TITLE
Advanced search limit results

### DIFF
--- a/src/scripts/models/search-results.coffee
+++ b/src/scripts/models/search-results.coffee
@@ -35,6 +35,7 @@ define (require) ->
     initialize: (options) ->
       @config(options)
       @set('loaded', false)
+      @set('timedout', false)
 
     config: (options = {}) ->
       @query = options.query or ''
@@ -54,18 +55,22 @@ define (require) ->
       return @
 
     fetch: () ->
+      fetchArgs = arguments[0]
+      fetchArgs.timeout = 60000 # one minute
       # Reset search results
       @clear({silent: true}).set(@defaults)
       @set('loaded', false)
 
-      return super(arguments...)
+      return super(fetchArgs)
       .always () =>
         @set('loaded', true)
         @unset('promise', {silent: true})
       .done () =>
         @set('error', false)
       .fail (model, response, options) =>
-        @set('error', response.status)
+        if (response == 'timeout')
+          @set('timedout', true)
+        @set('error', false)
 
     parse: (response, options) ->
       response = super(arguments...)

--- a/src/scripts/modules/search/advanced/advanced.coffee
+++ b/src/scripts/modules/search/advanced/advanced.coffee
@@ -9,10 +9,10 @@ define (require) ->
   require('less!./advanced')
 
   # Move this to helpers?
-  parseQuery = (qstr) ->
+  parseQuery = (locationString) ->
     query = {}
-    a = decodeURI(qstr.substr(1).split('&'))
-    criteriaMatch=a.match(/criteria=(.*)/)
+    criteriaMatch = decodeURI(locationString.substr(1))
+    .match(/criteria=(.*)/)
     if criteriaMatch
       criteriaPart = criteriaMatch[1]
       .match(/(\w+:((?:.(?!\w+:))+))/g)
@@ -41,9 +41,8 @@ define (require) ->
 
     onRender: () ->
       @regions.header.show(new SearchHeaderView())
-      $el = @$el
-      $.each(@criteria, (name, value) ->
-        $item = $el.find('[name^="'+name+'"]')
+      $.each(@criteria, (name, value) =>
+        $item = @$el.find("[name^=\"#{name}\"]")
         $item.val(value)
         )
 

--- a/src/scripts/modules/search/advanced/advanced.coffee
+++ b/src/scripts/modules/search/advanced/advanced.coffee
@@ -8,6 +8,21 @@ define (require) ->
   template = require('hbs!./advanced-template')
   require('less!./advanced')
 
+  # Move this to helpers?
+  parseQuery = (qstr) ->
+    query = {}
+    a = decodeURI(qstr.substr(1).split('&'))
+    criteriaMatch=a.match(/criteria=(.*)/)
+    if criteriaMatch
+      criteriaPart = criteriaMatch[1]
+      .match(/(\w+:((?:.(?!\w+:))+))/g)
+      $.each(criteriaPart, (i, entry) ->
+        pair = entry.split(':', 2)
+        valueNoQuotes = pair[1].match(/[^"]+/)
+        query[pair[0]] = valueNoQuotes[0]
+        )
+    query
+
   return class AdvancedSearchView extends BaseView
     template: template
     pageTitle: 'Advanced Search'
@@ -20,9 +35,17 @@ define (require) ->
 
     events:
       'submit form': 'submitForm'
+    initialize: () ->
+      super()
+      @criteria = parseQuery(window.location.search)
 
     onRender: () ->
       @regions.header.show(new SearchHeaderView())
+      $el = @$el
+      $.each(@criteria, (name, value) ->
+        $item = $el.find('[name^="'+name+'"]')
+        $item.val(value)
+        )
 
     submitForm: (e) ->
       e.preventDefault()

--- a/src/scripts/modules/search/header/header-template.html
+++ b/src/scripts/modules/search/header/header-template.html
@@ -13,7 +13,7 @@
   {{#if loaded}}
     {{#if results}}
       <span><strong>{{results.total}}</strong> results found</span>
-      <a href="/search" class="advanced-search btn">Advanced Search</a>
+      <a href="/search{{results.criteria}}" class="advanced-search btn">Advanced Search</a>
     {{/if}}
   {{/if}}
 </div>

--- a/src/scripts/modules/search/header/header.coffee
+++ b/src/scripts/modules/search/header/header.coffee
@@ -8,4 +8,5 @@ define (require) ->
 
     initialize: () ->
       super()
+      @model?.attributes.results.criteria = window.location.search.replace('q=', 'criteria=')
       @listenTo(@model, 'change:results change:loaded', @render) if @model

--- a/src/scripts/modules/search/results/list/list-template.html
+++ b/src/scripts/modules/search/results/list/list-template.html
@@ -17,7 +17,13 @@
   {{/if}}
 {{else}}
   {{#if loaded}}
-    <p>No results found. Please try expanding your search.</p>
+    {{#if timedout}}
+      <p>The search seems to be taking a long time. The search engine may have the
+      results ready if you reload the page. Otherwise, go back and adjust your
+      search.</p>
+    {{else}}
+      <p>No results found. Please try expanding your search.</p>
+    {{/if}}
   {{else}}
     <div class="progress progress-striped active">
       <div class="progress-bar secondary" role="progressbar" style="width: 100%">

--- a/src/scripts/pages/error/error.coffee
+++ b/src/scripts/pages/error/error.coffee
@@ -19,6 +19,7 @@ define (require) ->
         switch @error.code
           when 403 then @error.reason = 'Forbidden'
           when 404 then @error.reason = 'Page Not Found'
+          when 408 then @error.reason = 'Request Timed Out'
           when 500 then @error.reason = 'Internal Server Error'
           when 503 then @error.reason = 'Service Unavailable'
           else @error.reason = 'Unknown Error'


### PR DESCRIPTION
Set search to timeout at 1 minute. Inform user they can try reloading,
or refining. Advanced Search button carries new “criteria” parameter
along, which pre-fills the form the way they had it.