### PR TITLE
Wording tweak

### DIFF
--- a/src/scripts/modules/search/results/list/list-template.html
+++ b/src/scripts/modules/search/results/list/list-template.html
@@ -19,8 +19,8 @@
   {{#if loaded}}
     {{#if timedout}}
       <p>The search seems to be taking a long time. The search engine may have the
-      results ready if you reload the page. Otherwise, go back and adjust your
-      search.</p>
+      results ready if you reload the page, or you can refine your search using
+      the Advanced Search button above.</p>
     {{else}}
       <p>No results found. Please try expanding your search.</p>
     {{/if}}


### PR DESCRIPTION
Ed wanted the search timeout to explicitly refer to Advanced Search. This got a “looks good”.