### PR TITLE
Search criteria fix

### DIFF
--- a/src/scripts/modules/search/advanced/advanced.coffee
+++ b/src/scripts/modules/search/advanced/advanced.coffee
@@ -15,8 +15,14 @@ define (require) ->
     .match(/criteria=(.*)/)
     if criteriaMatch
       criteriaPart = criteriaMatch[1]
-      .match(/(\w+:((?:.(?!\w+:))+))/g)
-      $.each(criteriaPart, (i, entry) ->
+      .match(///
+      (\w+:   # query field, colon
+        (     # Series of...
+          (?:.(?!\w+:))+  # character not followed by query field+colon
+        )
+      )
+      ///g)
+      if criteriaPart? then $.each(criteriaPart, (i, entry) ->
         pair = entry.split(':', 2)
         valueNoQuotes = pair[1].match(/[^"]+/)
         query[pair[0]] = valueNoQuotes[0]


### PR DESCRIPTION
The Advanced Search field-filling routine was failing for searches that
did not have queryField:term format (such as come from the Search box)