### PR TITLE
Aria attributes for tabs

### DIFF
--- a/src/scripts/modules/media/footer/footer-template.html
+++ b/src/scripts/modules/media/footer/footer-template.html
@@ -1,25 +1,25 @@
 <div class="media-footer">
-  <ul>
-    <li class="tab" data-content="downloads" tabindex="0">
+  <ul role="tablist">
+    <li id="downloads-tab" class="tab" data-content="downloads" tabindex="0" role="tab">
       <span class="tab-title">Downloads</span>
     </li>
-    <li class="tab" data-content="history" tabindex="0">
+    <li id="history-tab" class="tab" data-content="history" tabindex="0" role="tab">
       <span class="tab-title">History</span>
     </li>
-    <li class="tab" data-content="attribution" tabindex="0">
+    <li id="attribution-tab" class="tab" data-content="attribution" tabindex="0" role="tab">
       <span class="tab-title">Attribution</span>
     </li>
   </ul>
 
-  <div class="downloads tab-content">
+  <div class="downloads tab-content" role="tabpanel" aria-labelledby="downloads-tab">
     {{! Downloads View }}
   </div>
 
-  <div class="history tab-content">
+  <div class="history tab-content" role="tabpanel" aria-labelledby="history-tab">
     {{! History View }}
   </div>
 
-  <div class="attribution tab-content">
+  <div class="attribution tab-content" role="tabpanel" aria-labelledby="attribution-tab">
     {{! Attribution View }}
   </div>
 

--- a/src/scripts/modules/media/footer/footer.coffee
+++ b/src/scripts/modules/media/footer/footer.coffee
@@ -52,13 +52,13 @@ define (require) ->
       $allTabs = @$el.find('.tab')
       $allTabs.addClass('inactive')
       $allTabs.removeClass('active')
-      @$el.find('.tab-content').hide()
+      @$el.find('.tab-content').hide().attr('aria-hidden', 'true')
 
       if $tab.data('content') isnt @currentTab
         $tab.removeClass('inactive')
         $tab.addClass('active')
         @currentTab = $tab.data('content')
-        @$el.find(".#{@currentTab}").show()
+        @$el.find(".#{@currentTab}").show().removeAttr('aria-hidden')
       else
         @currentTab = null
         $allTabs.removeClass('inactive')

--- a/src/scripts/modules/media/tabs/tabs.coffee
+++ b/src/scripts/modules/media/tabs/tabs.coffee
@@ -52,14 +52,14 @@ define (require) ->
       $allTabs.addClass('inactive')
       $allTabs.removeClass('active')
       $allTabs.attr('aria-selected', 'false')
-      @$el.find('.tab-content').hide()
+      @$el.find('.tab-content').hide().attr('aria-hidden', 'true')
 
     showTab: ($tab) ->
       $tab.removeClass('inactive')
       $tab.addClass('active')
       $tab.attr('aria-selected', 'true')
       @currentTab = $tab.data('content')
-      @$el.find(".#{@currentTab}").show()
+      @$el.find(".#{@currentTab}").show().removeAttr('aria-hidden')
 
     closeTabs: () ->
       $allTabs = @$el.find('.tab')


### PR DESCRIPTION
Header tabs and footer tabs have role attributes. Tab content panes
have “tabpanel” role and have aria-hidden=“true” when hidden, and are
tied back to tab ids via aria-labelledby attribute.