### PR TITLE
Only exclude downloads whose state is not good

### DIFF
--- a/src/scripts/models/contents/node.coffee
+++ b/src/scripts/models/contents/node.coffee
@@ -84,9 +84,7 @@ define (require) ->
               url: "#{ARCHIVE}/extras/#{@getVersionedId()}"
               dataType: 'json'
             .done (response) =>
-              validDownloads = response.downloads.filter (info) ->
-                info.state is 'good'
-              @set('downloads', validDownloads)
+              @set('downloads', response.downloads)
               @set('isLatest', response.isLatest)
               @set('canPublish', response.canPublish)
             .fail () =>

--- a/src/scripts/models/contents/node.coffee
+++ b/src/scripts/models/contents/node.coffee
@@ -85,7 +85,7 @@ define (require) ->
               dataType: 'json'
             .done (response) =>
               validDownloads = response.downloads.filter (info) ->
-                info.size > 0 and info.format isnt 'EPUB'
+                info.state is 'good'
               @set('downloads', validDownloads)
               @set('isLatest', response.isLatest)
               @set('canPublish', response.canPublish)

--- a/src/scripts/modules/media/header/popovers/book/book-template.html
+++ b/src/scripts/modules/media/header/popovers/book/book-template.html
@@ -10,7 +10,9 @@
       <h5>Download Book:</h5>
       <ul>
         {{#each downloads}}
-          <li><a href="{{path}}" data-prop="true">{{format}}</a></li>
+          {{#is state 'good'}}
+            <li><a href="{{path}}" data-prop="true">{{format}}</a></li>
+          {{/is}}
         {{/each}}
       </ul>
     </div>

--- a/src/scripts/modules/media/header/popovers/book/book-template.html
+++ b/src/scripts/modules/media/header/popovers/book/book-template.html
@@ -23,7 +23,9 @@
       <h5>Download Page:</h5>
       <ul>
         {{#each currentPage.downloads}}
-          <li><a href="{{path}}" data-prop="true">{{format}}</a></li>
+          {{#is state 'good'}}
+            <li><a href="{{path}}" data-prop="true">{{format}}</a></li>
+          {{/is}}
         {{/each}}
       </ul>
     </div>


### PR DESCRIPTION
Turns out we don’t want to restrict EPUBs specifically.