### PR TITLE
Remove superfluous img width restraint

### DIFF
--- a/src/scripts/modules/media/body/content.less
+++ b/src/scripts/modules/media/body/content.less
@@ -110,9 +110,6 @@ figure {
   > figure {
     counter-increment: subfigure;
 
-    // do not wrap this in a .media so it applies to editing in Aloha
-    img { max-width: 50%; }
-
     &.ui-has-child-figcaption > figcaption::before {
       font-weight: bold;
       content: counter(figure) counter(subfigure,lower-alpha) ': ';


### PR DESCRIPTION
Don't constrain img width further than necessary (it's already constrained by the figure it's in).

Fixes:
http://cnx.org/contents/8fee8a58-183e-4ac9-8b56-4dc08b25cca4@1.1:16/Sources-for-Fords-Cavalry-tril
http://legacy.cnx.org/content/m41024/1.1/
