### PR TITLE
Heading hierarchy

### DIFF
--- a/src/scripts/modules/featured-books/featured-books-partial.html
+++ b/src/scripts/modules/featured-books/featured-books-partial.html
@@ -1,6 +1,6 @@
 <div class="book">
   <a href="{{link}}" tabindex="-1"><img src="{{cover}}" width="125" height="162" alt="{{title}}" /></a>
-  <h4 id="fb-{{prefix}}-{{id}}-title"><a href="{{link}}">{{title}}</a></h4>
+  <h3 id="fb-{{prefix}}-{{id}}-title" class="small-header"><a href="{{link}}">{{title}}</a></h3>
   <p>{{description}}</p>
   <div class="read-more"><a href="{{link}}" aria-labelledby="fb-{{prefix}}-{{id}}-title">Read More</a></div>
 </div>

--- a/src/scripts/modules/featured-books/featured-books.less
+++ b/src/scripts/modules/featured-books/featured-books.less
@@ -50,7 +50,7 @@
         border: 0;
       }
 
-      h4 {
+      h3 {
         margin-bottom: 1rem;
 
         a {

--- a/src/scripts/modules/media/footer/attribution/attribution-template.html
+++ b/src/scripts/modules/media/footer/attribution/attribution-template.html
@@ -1,4 +1,4 @@
-<h3>How to Reuse &amp; Attribute This Content</h3>
+<h2 class="medium-header">How to Reuse &amp; Attribute This Content</h2>
 
 {{> modules/media/footer/inherits/tab/toggle-partial }}
 

--- a/src/scripts/modules/media/footer/downloads/downloads-template.html
+++ b/src/scripts/modules/media/footer/downloads/downloads-template.html
@@ -1,4 +1,4 @@
-<h3>Downloads</h3>
+<h2 class="medium-header">Downloads</h2>
 
 {{> modules/media/footer/inherits/tab/toggle-partial }}
 

--- a/src/scripts/modules/media/footer/footer.less
+++ b/src/scripts/modules/media/footer/footer.less
@@ -4,7 +4,7 @@
 .media-footer {
   margin: 4rem 6rem 6rem 6rem;
 
-  h3 {
+  h2 {
     margin-bottom: 2rem;
     font-weight: 300;
   }

--- a/src/scripts/modules/media/footer/history/history-template.html
+++ b/src/scripts/modules/media/footer/history/history-template.html
@@ -1,4 +1,4 @@
-<h3>Version History</h3>
+<h2 class="medium-header">Version History</h2>
 
 {{> modules/media/footer/inherits/tab/toggle-partial }}
 

--- a/src/scripts/modules/media/header/popovers/book/book-template.html
+++ b/src/scripts/modules/media/header/popovers/book/book-template.html
@@ -1,35 +1,35 @@
 <div class="book-popover">
   <div class="header">
     <img src="/images/icons/download.png" width="16" height="16" alt="Download" />
-    <h4>Get This Book</h4>
+    <h2 class="small-header">Get This Book</h2>
     <p>{{! Copy}}</p>
+
+    {{#if downloads}}
+      <div class="download-book">
+        <h3 class="extra-small-header">Download Book:</h3>
+        <ul>
+          {{#each downloads}}
+            {{#is state 'good'}}
+              <li><a href="{{path}}" data-prop="true">{{format}}</a></li>
+            {{/is}}
+          {{/each}}
+        </ul>
+      </div>
+    {{/if}}
+
+    {{#if currentPage.downloads}}
+      <div class="download-page">
+        <h3 class="extra-small-header">Download Page:</h3>
+        <ul>
+          {{#each currentPage.downloads}}
+            {{#is state 'good'}}
+              <li><a href="{{path}}" data-prop="true">{{format}}</a></li>
+            {{/is}}
+          {{/each}}
+        </ul>
+      </div>
+    {{/if}}
   </div>
-
-  {{#if downloads}}
-    <div class="download-book">
-      <h5>Download Book:</h5>
-      <ul>
-        {{#each downloads}}
-          {{#is state 'good'}}
-            <li><a href="{{path}}" data-prop="true">{{format}}</a></li>
-          {{/is}}
-        {{/each}}
-      </ul>
-    </div>
-  {{/if}}
-
-  {{#if currentPage.downloads}}
-    <div class="download-page">
-      <h5>Download Page:</h5>
-      <ul>
-        {{#each currentPage.downloads}}
-          {{#is state 'good'}}
-            <li><a href="{{path}}" data-prop="true">{{format}}</a></li>
-          {{/is}}
-        {{/each}}
-      </ul>
-    </div>
-  {{/if}}
 
   {{#if buyLink}}
     <a href="{{buyLink}}" class="btn order">Order Printed Book</a>

--- a/src/scripts/modules/media/header/popovers/book/book.less
+++ b/src/scripts/modules/media/header/popovers/book/book.less
@@ -5,12 +5,12 @@
   padding: 0.6rem 1.4rem;
 
   .header {
-    h4, img {
+    h2, img {
       display: inline-block;
       vertical-align: middle;
     }
 
-    h4 {
+    h2 {
       margin-left: 0.5rem;
     }
 
@@ -20,7 +20,7 @@
     }
   }
 
-  h5 {
+  h3 {
     color: @gray;
   }
 

--- a/src/scripts/modules/media/title/title-template.html
+++ b/src/scripts/modules/media/title/title-template.html
@@ -15,12 +15,12 @@
     {{/if}}
 
     <div class="title">
-      <h2>
+      <h1 class="large-header">
         {{#is status 'publishing'}}
           <span class="label label-info">publishing</span>
         {{/is}}
         {{title}}
-      </h2>
+      </h1>
       {{#if parent.id}}
         <span>
           Derived from <a href="/contents/{{parent.id}}@{{parent.version}}">{{parent.title}}</a> by

--- a/src/scripts/modules/media/title/title.less
+++ b/src/scripts/modules/media/title/title.less
@@ -23,7 +23,7 @@
       margin-right: 7%;
       width: 60%;
 
-      > h2 {
+      > h1 {
         font-weight: 400;
       }
 

--- a/src/scripts/modules/search/results/filter/filter-template.html
+++ b/src/scripts/modules/search/results/filter/filter-template.html
@@ -1,8 +1,8 @@
-<h3>Filters</h3>
+<h2 class="medium-header">Filters</h2>
 <ul class="filters">
   {{#each results.limits}}
     <li>
-      <h5 class="filter-name">{{name}}</h5>
+      <h3 class="filter-name extra-small-header">{{name}}</h3>
       <dl class="dl-horizontal {{#gt values.length 6}}collapsed{{/gt}}">
         {{#each values}}
           <dt class="limit {{#gt @index 5}}overflow hidden{{/gt}}">

--- a/src/scripts/modules/search/results/filter/filter.less
+++ b/src/scripts/modules/search/results/filter/filter.less
@@ -4,13 +4,13 @@
   padding: 1.5rem;
   background-color: @gray-lightest;
 
-  h3 {
+  h2 {
     padding-bottom: 1rem;
     border-bottom: 0.1rem solid white;
     font-weight: 400;
   }
 
-  h5 {
+  h3 {
     color: black;
   }
 

--- a/src/scripts/pages/about/default/default-template.html
+++ b/src/scripts/pages/about/default/default-template.html
@@ -7,7 +7,7 @@
   <p>There are tens of thousands of learning objects, called <b>pages</b>, that are organized into thousands of textbook-style <b>books</b> in a host of disciplines, all easily accessible online and downloadable to almost any device, anywhere, anytime.</p>
   <p>The best part? Everything is available for free thanks to generous support from Rice University and several philanthropic organizations.</p>
 
-  <h1>How it works</h1>
+  <h2>How it works</h2>
 
   <h3>Authors can:</h3>
 
@@ -17,7 +17,7 @@
 
   <img src="/images/about/learning.svg" alt="Graphic of learning process: View, Download, and Use on Mobile Devices"/>
 
-  <h1>Frictionless Remix</h1>
+  <h2>Frictionless Remix</h2>
 
   <p>OpenStax CNX is designed to encourage the sharing and reuse of educational content. The knowledge in OpenStax CNX can be shared and built upon by all because it is reusable:</p>
 

--- a/src/scripts/pages/about/people/people-template.html
+++ b/src/scripts/pages/about/people/people-template.html
@@ -16,7 +16,7 @@
           {{else}}
             <img alt="{{name}}" src="/images/people/foundations/{{image}}" />
           {{/if}}
-          <h4 class="sr-only">{{name}}</h4>
+          <h3 class="sr-only">{{name}}</h3>
           <p>{{about}}</p>
         </li>
       {{/each}}

--- a/src/scripts/pages/donate/default/default-template.html
+++ b/src/scripts/pages/donate/default/default-template.html
@@ -2,7 +2,7 @@
   <h1>Support OpenStax CNX</h1>
 
   <div class="support">
-    <h3>Your donation makes a difference</h3>
+    <h2 class="medium-header">Your donation makes a difference</h2>
     <p>Your donation helps keep OpenStax CNX's rapidly growing repository of educational materials vibrant,
       free, and available to educators and learners all over the world.</p>
 


### PR DESCRIPTION
Closed gaps in h-levels: h2 comes after h1; h3 comes after h2, etc., not
h5 after h3 after h1. Adjusted classes and .less files so most render
the same as before, rather than changing size. Exception: On “About
Us”, allowed “How it works” and “Frictionless Remix” to be smaller than
top-of-page header.