### PR TITLE
Toc numbering

### DIFF
--- a/src/scripts/modules/media/tabs/contents/toc/page-template.html
+++ b/src/scripts/modules/media/tabs/contents/toc/page-template.html
@@ -1,9 +1,8 @@
 <div {{#if editable}}draggable="true"{{/if}}>
   <span class="name-wrapper">
     <a href="{{url}}" data-page="{{page}}" data-trigger="false">
-      <span class="title {{#if active}}active{{/if}}" data-depth="{{depth}}">{{title}}</span>
+      <span class="title{{#is numbered false}} not-numbered{{/is}}{{#if active}} active{{/if}}" data-depth="{{depth}}">{{title}}</span>
     </a>
-
     {{~#if changed}}
       <small><i>changed</i></small>
     {{/if~}}

--- a/src/scripts/modules/media/tabs/contents/toc/section.coffee
+++ b/src/scripts/modules/media/tabs/contents/toc/section.coffee
@@ -24,6 +24,11 @@ define (require) ->
       @regions =
         container: @itemViewContainer
       @sectionNameModal = new SectionNameModal({model: @model})
+      ###
+      The TOC numbering solution below only applies to OpenStax books, which are
+      identified by a print style starting with "ccao-"
+      ###
+      @isCcap = @content.get('printStyle')?.match(/^ccap-/i)
 
       super()
 
@@ -42,12 +47,17 @@ define (require) ->
             model: node
         else
           ###
-          The real condition is testing the "numbered" attribute
-          If it exists, it should be false, meaning skip number
+          Do not number pages that are the first in their section and whose
+          title begins with "Introduction"
+          !!!
+          This is an interim solution to the TOC numbering problem, which is
+          probably imperfect.
+          !!!
           ###
-          numbered = not(idx is 0 && node.get('title').match(/^Introduction/))
-          if numbered == false
-            node.set('numbered', false)
+          if (@isCcap?)
+            numbered = not(idx is 0 && node.get('title').match(/^Introduction/))
+            if numbered == false
+              node.set('numbered', false)
           @regions.container.appendAs 'li', new TocPageView
             model: node
             collection: @model

--- a/src/scripts/modules/media/tabs/contents/toc/section.coffee
+++ b/src/scripts/modules/media/tabs/contents/toc/section.coffee
@@ -36,11 +36,18 @@ define (require) ->
 
       nodes = @model.get('contents')?.models
 
-      _.each nodes, (node) =>
+      _.each nodes, (node, idx) =>
         if node.isSection()
           @regions.container.appendAs 'li', new TocSectionView
             model: node
         else
+          ###
+          The real condition is testing the "numbered" attribute
+          If it exists, it should be false, meaning skip number
+          ###
+          numbered = not(idx is 0 && node.get('title').match(/^Introduction/))
+          if numbered == false
+            node.set('numbered', false)
           @regions.container.appendAs 'li', new TocPageView
             model: node
             collection: @model

--- a/src/scripts/modules/media/tabs/contents/toc/section.less
+++ b/src/scripts/modules/media/tabs/contents/toc/section.less
@@ -8,13 +8,13 @@
     counter-reset: section;
     list-style-type: none;
 
-    li .title:not([data-depth="0"])::before {
+    li .title:not([data-depth="0"]):not(.not-numbered)::before {
       display: inline-block;
       margin-right: 0.5rem;
       font-weight: bold;
       color: @brand-primary;
       counter-increment: section;
-      content: counters(section, "-") ".";
+      content: counters(section, ".") "";
     }
   }
 }


### PR DESCRIPTION
To resolve the numbering mismatch between PDF and online, for books with printStyle beginning with “ccap-“:
Pages that are the first page in a section and whose title begins with “Introduction” are not numbered.