### PR TITLE
Toc unit numbering

### DIFF
--- a/src/scripts/modules/media/tabs/contents/contents.coffee
+++ b/src/scripts/modules/media/tabs/contents/contents.coffee
@@ -5,6 +5,40 @@ define (require) ->
   template = require('hbs!./contents-template')
   require('less!./contents')
 
+  cumulativeChapters = []
+  numberChapters = (toc, depth=0) ->
+    sectionNumber = 0
+    for item in toc
+      isSection = not item.get('contents')?
+      isCcap = (item.get('book')?.get('printStyle') ? '').match(/^ccap-/)?
+      if isSection
+        title = item.get('title')
+        atTopLevel = cumulativeChapters.length == 0
+        chapterNumber = cumulativeChapters[depth - 1]
+        if not isCcap
+          chapterNumber = cumulativeChapters.slice(0,depth).join('.')
+          sectionNumber = cumulativeChapters[depth] ? 0
+        if not (
+          atTopLevel or
+          isCcap and sectionNumber is 0 and title.match(/^Introduction/)
+        )
+          sectionNumber += 1
+          cumulativeChapters[depth] = sectionNumber
+          item.set('chapter', "#{chapterNumber}.#{sectionNumber}")
+      else
+        if cumulativeChapters[depth]?
+          cumulativeChapters[depth] += 1
+        else
+          cumulativeChapters[depth] = 1
+        contentsModels = item.get('contents')?.models
+        if not isCcap
+          cumulativeChapters[depth + 1] = 0
+          chapterNumber = cumulativeChapters.slice(0,depth+1).join('.')
+        else
+          chapterNumber = cumulativeChapters[depth]
+        numberChapters(contentsModels, depth+1) if contentsModels?
+        item.set('chapter', chapterNumber)
+
   return class ContentsView extends BaseView
     template: template
 
@@ -18,6 +52,8 @@ define (require) ->
     initialize: () ->
       super()
       @listenTo(@model, 'change:editable removeNode moveNode add:contents', @render)
+      cumulativeChapters = []
+      numberChapters(@model.attributes.contents.models) if @model.attributes.contents?.models?
 
     onRender: () ->
       @regions.toc.show new TocSectionView

--- a/src/scripts/modules/media/tabs/contents/contents.coffee
+++ b/src/scripts/modules/media/tabs/contents/contents.coffee
@@ -13,7 +13,7 @@ define (require) ->
       isCcap = (item.get('book')?.get('printStyle') ? '').match(/^ccap-/)?
       if isSection
         title = item.get('title')
-        atTopLevel = cumulativeChapters.length == 0
+        atTopLevel = depth == 0
         chapterNumber = cumulativeChapters[depth - 1]
         if not isCcap
           chapterNumber = cumulativeChapters.slice(0,depth).join('.')

--- a/src/scripts/modules/media/tabs/contents/toc/page-template.html
+++ b/src/scripts/modules/media/tabs/contents/toc/page-template.html
@@ -1,7 +1,10 @@
 <div {{#if editable}}draggable="true"{{/if}}>
   <span class="name-wrapper">
+    {{#if chapter}}<span class="chapter-number">{{chapter}}</span>{{/if}}
     <a href="{{url}}" data-page="{{page}}" data-trigger="false">
-      <span class="title{{#is numbered false}} not-numbered{{/is}}{{#if active}} active{{/if}}" data-depth="{{depth}}">{{title}}</span>
+      <span class="title{{#if active}} active{{/if}}" data-depth="{{depth}}">
+        {{title}}
+      </span>
     </a>
     {{~#if changed}}
       <small><i>changed</i></small>

--- a/src/scripts/modules/media/tabs/contents/toc/section-template.html
+++ b/src/scripts/modules/media/tabs/contents/toc/section-template.html
@@ -1,7 +1,11 @@
 {{#if book}} {{! Only display if the model has a reference to the book, and therefore is not the book }}
   <div {{#if editable}}draggable="true"{{/if}} data-expandable="true" {{#if expanded}}data-expanded="true"{{/if}}>
-    <span class="section-wrapper name-wrapper" tabindex="0" {{#if expanded}}aria-expanded="true"{{else}}aria-expanded="false"{{/if}}>
-      <span class="title section">{{title}}</span>
+    <span class="section-wrapper name-wrapper" tabindex="0"
+     {{#if expanded}}aria-expanded="true"{{else}}aria-expanded="false"{{/if}}>
+     {{#if chapter}}<span class="chapter-number">{{chapter}}</span>{{/if}}
+      <span class="title section">
+        {{title}}
+      </span>
     </span>
 
     {{~#if editable~}}

--- a/src/scripts/modules/media/tabs/contents/toc/section.coffee
+++ b/src/scripts/modules/media/tabs/contents/toc/section.coffee
@@ -24,11 +24,6 @@ define (require) ->
       @regions =
         container: @itemViewContainer
       @sectionNameModal = new SectionNameModal({model: @model})
-      ###
-      The TOC numbering solution below only applies to OpenStax books, which are
-      identified by a print style starting with "ccao-"
-      ###
-      @isCcap = @content.get('printStyle')?.match(/^ccap-/i)
 
       super()
 
@@ -41,23 +36,11 @@ define (require) ->
 
       nodes = @model.get('contents')?.models
 
-      _.each nodes, (node, idx) =>
+      _.each nodes, (node) =>
         if node.isSection()
           @regions.container.appendAs 'li', new TocSectionView
             model: node
         else
-          ###
-          Do not number pages that are the first in their section and whose
-          title begins with "Introduction"
-          !!!
-          This is an interim solution to the TOC numbering problem, which is
-          probably imperfect.
-          !!!
-          ###
-          if (@isCcap?)
-            numbered = not(idx is 0 && node.get('title').match(/^Introduction/))
-            if numbered == false
-              node.set('numbered', false)
           @regions.container.appendAs 'li', new TocPageView
             model: node
             collection: @model

--- a/src/scripts/modules/media/tabs/contents/toc/section.less
+++ b/src/scripts/modules/media/tabs/contents/toc/section.less
@@ -5,16 +5,15 @@
   ul {
     padding: 0 2rem;
     font-size: 1.25rem;
-    counter-reset: section;
     list-style-type: none;
 
-    li .title:not([data-depth="0"]):not(.not-numbered)::before {
-      display: inline-block;
-      margin-right: 0.5rem;
+    li .chapter-number {
       font-weight: bold;
+      margin-right: 0.25rem;
       color: @brand-primary;
-      counter-increment: section;
-      content: counters(section, ".") "";
+      &::after {
+        content: ".";
+      }
     }
   }
 }

--- a/src/scripts/modules/media/tabs/contents/toc/section.less
+++ b/src/scripts/modules/media/tabs/contents/toc/section.less
@@ -9,7 +9,6 @@
 
     li .chapter-number {
       font-weight: bold;
-      margin-right: 0.25rem;
       color: @brand-primary;
       &::after {
         content: ".";


### PR DESCRIPTION
CSS numbering cannot work for sequential chapters, because unexpanded
sections are not on the page and so cannot be counted. This patch
applies a “chapter” attribute to TOC model entries and includes it in
the HTML, with CSS styling similar to the old CSS-numbered chapters.
Books with a printStyle attribute like ccap-* have continuously
numbered chapters, all bottom-level entities are numbered #.#, and
higher level entities are just #.
Non-ccap books are numbered old-style, with all levels of numbers (e.g.
5 > 5.1 > 5.1.1)