### PR TITLE
Cc load initial

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -23,7 +23,7 @@
     "require-handlebars-plugin": "1.0.0",
     "aloha-editor": "oerpub/Aloha-Editor#master",
     "select2": "3.5.4",
-    "concept-coach": "openstax/concept-coach#db7f6c5"
+    "concept-coach": "openstax/concept-coach#4c6611b"
   },
   "devDependencies": {
     "chai": "3.2.0",

--- a/bower.json
+++ b/bower.json
@@ -23,7 +23,7 @@
     "require-handlebars-plugin": "1.0.0",
     "aloha-editor": "oerpub/Aloha-Editor#master",
     "select2": "3.5.4",
-    "concept-coach": "openstax/concept-coach#915c648"
+    "concept-coach": "openstax/concept-coach#db7f6c5"
   },
   "devDependencies": {
     "chai": "3.2.0",

--- a/bower.json
+++ b/bower.json
@@ -23,7 +23,7 @@
     "require-handlebars-plugin": "1.0.0",
     "aloha-editor": "oerpub/Aloha-Editor#master",
     "select2": "3.5.4",
-    "concept-coach": "openstax/concept-coach#4c6611b"
+    "concept-coach": "openstax/concept-coach#2fc42bf"
   },
   "devDependencies": {
     "chai": "3.2.0",

--- a/bower.json
+++ b/bower.json
@@ -23,7 +23,7 @@
     "require-handlebars-plugin": "1.0.0",
     "aloha-editor": "oerpub/Aloha-Editor#master",
     "select2": "3.5.4",
-    "concept-coach": "openstax/concept-coach#c9cab5a"
+    "concept-coach": "openstax/concept-coach#915c648"
   },
   "devDependencies": {
     "chai": "3.2.0",

--- a/bower.json
+++ b/bower.json
@@ -22,7 +22,8 @@
     "require-less": "0.1.5",
     "require-handlebars-plugin": "1.0.0",
     "aloha-editor": "oerpub/Aloha-Editor#master",
-    "select2": "3.5.4"
+    "select2": "3.5.4",
+    "concept-coach": "openstax/concept-coach#c9cab5a"
   },
   "devDependencies": {
     "chai": "3.2.0",

--- a/src/scripts/config.js
+++ b/src/scripts/config.js
@@ -26,6 +26,8 @@
       // Use Minified Aloha because loading files in a different requirejs context is a royal pain
       aloha: '../../bower_components/aloha-editor/target/build-profile-with-oer/rjs-output/lib/aloha',
 
+      OpenStaxReactComponents: '../../bower_components/concept-coach/dist/full-build.min',
+
       // ## UI Libraries and Helpers
       tooltip: 'helpers/backbone/views/attached/tooltip/tooltip',
       popover: 'helpers/backbone/views/attached/popover/popover',

--- a/src/scripts/modules/media/body/body-template.html
+++ b/src/scripts/modules/media/body/body-template.html
@@ -8,6 +8,11 @@
         {{include content}}
       </div>
     </div>
+    {{#if isCoach}}
+    <div class="concept-coach-launcher">
+      <button type="button" class="btn">Open Concept Coach</button>
+    </div>
+    {{/if}}
   {{/if}}
 {{else}}
   <div class="media-body" aria-busy="true">

--- a/src/scripts/modules/media/body/body-template.html
+++ b/src/scripts/modules/media/body/body-template.html
@@ -10,7 +10,7 @@
     </div>
     {{#if isCoach}}
     <div class="concept-coach-launcher">
-      <button type="button" class="btn">Open Concept Coach</button>
+      <button type="button" class="btn">Open <span class="cc-logo"><strong>Concept</strong>Coach</span></button>
     </div>
     {{/if}}
   {{/if}}

--- a/src/scripts/modules/media/body/body.coffee
+++ b/src/scripts/modules/media/body/body.coffee
@@ -69,7 +69,7 @@ define (require) ->
         $els.hide()
 
     intializeConceptCoach: ->
-      return unless @templateHelpers.isCoach()
+      return unless @templateHelpers.isCoach.call(@)
       $body = $('body')
 
       animatedScroll = (top) ->

--- a/src/scripts/modules/media/body/body.coffee
+++ b/src/scripts/modules/media/body/body.coffee
@@ -52,11 +52,11 @@ define (require) ->
       'click .concept-coach-launcher > button': 'launchConceptCoach'
 
     initialize: () ->
-      cc.init('http://localhost:3001')
       super()
       @listenTo(@model, 'change:loaded', @render)
       @listenTo(@model, 'change:currentPage change:currentPage.active change:currentPage.loaded', @render)
       @listenTo(@model, 'change:currentPage.editable', @render)
+      @intializeConceptCoach()
 
     updateTeacher: ($temp = @$el) ->
       $els = $temp.find('.os-teacher')
@@ -66,10 +66,31 @@ define (require) ->
       else
         $els.hide()
 
+    intializeConceptCoach: ->
+      $body = $('body')
+
+      animatedScroll = (top) ->
+        $('html, body').animate({scrollTop: top}, '500', 'swing')
+
+      handleOpen = (eventData) ->
+        cc.handleOpened(eventData, animatedScroll, $body[0])
+
+      handleClose = (eventData) ->
+        cc.handleClosed(eventData, $body[0])
+
+      cc.init('http://localhost:3001')
+      cc.on('ui.close', handleClose)
+      cc.on('open', handleOpen)
+
     launchConceptCoach: (event) ->
-      collectionUUID = @model.getUuid()
-      moduleUUID = @model.get('currentPage').getUuid()
-      cc.open(document.body, {collectionUUID, moduleUUID})
+      unless cc.component?.isMounted()
+        $button = $(event.currentTarget)
+
+        collectionUUID = @model.getUuid()
+        moduleUUID = @model.get('currentPage').getUuid()
+
+        cc.open($button.parent()[0], {collectionUUID, moduleUUID})
+
 
     # Toggle the visibility of teacher's edition elements
     toggleTeacher: () ->

--- a/src/scripts/modules/media/body/body.coffee
+++ b/src/scripts/modules/media/body/body.coffee
@@ -6,6 +6,7 @@ define (require) ->
   EditableView = require('cs!helpers/backbone/views/editable')
   ProcessingInstructionsModal = require('cs!./processing-instructions/modals/processing-instructions')
   SimModal = require('cs!./embeddables/modals/sims/sims')
+  require('bootstrapModal')
   template = require('hbs!./body-template')
   require('less!./body')
 
@@ -33,6 +34,8 @@ define (require) ->
           return @model.asPage()?.get('loaded')
 
         return @model.get('loaded')
+      isCoach: ->
+        return true
 
     editable:
       '.media-body':
@@ -46,6 +49,7 @@ define (require) ->
       'keydown .media-body': 'checkKeySequence'
       'keyup .media-body': 'resetKeySequence'
       'click .os-interactive-link': 'simLink'
+      'click .concept-coach-launcher > button': 'launchConceptCoach'
 
     initialize: () ->
       super()
@@ -60,6 +64,12 @@ define (require) ->
         $els.show()
       else
         $els.hide()
+
+    launchConceptCoach: (event) ->
+      $modalDiv = $('cc-modal')
+      $modalDiv.modal()
+      $modalDiv.modal('show')
+      console.debug("DIV:", $modalDiv)
 
     # Toggle the visibility of teacher's edition elements
     toggleTeacher: () ->
@@ -357,6 +367,10 @@ define (require) ->
 
 
     onRender: () ->
+      $('<div id="cc-modal">').height('300px').width('600px').text('There is no I in TEAM')
+        .addClass('modal fade').appendTo(document.body)
+
+
       if @model.asPage()?.get('loaded') and @model.isDraft()
         @parent?.regions.self.append(new ProcessingInstructionsModal({model: @model}))
 

--- a/src/scripts/modules/media/body/body.coffee
+++ b/src/scripts/modules/media/body/body.coffee
@@ -15,13 +15,6 @@ define (require) ->
     'exercise': require('hbs!./embeddables/exercise-template')
     'iframe': require('hbs!./embeddables/iframe-template')
 
-  # fakeExerciseTemplates = [
-  #   require('hbs!./embeddables/fake-exercises/ex001')
-  #   require('hbs!./embeddables/fake-exercises/ex002')
-  #   require('hbs!./embeddables/fake-exercises/ex003')
-  #   require('hbs!./embeddables/fake-exercises/ex004')
-  # ]
-
   return class MediaBodyView extends EditableView
     key = []
     media: 'page'

--- a/src/scripts/modules/media/body/body.coffee
+++ b/src/scripts/modules/media/body/body.coffee
@@ -66,7 +66,7 @@ define (require) ->
         $els.hide()
 
     launchConceptCoach: (event) ->
-      $modalDiv = $('cc-modal')
+      $modalDiv = $('#cc-modal')
       $modalDiv.modal()
       $modalDiv.modal('show')
       console.debug("DIV:", $modalDiv)
@@ -368,7 +368,11 @@ define (require) ->
 
     onRender: () ->
       $('<div id="cc-modal">').height('300px').width('600px').text('There is no I in TEAM')
-        .addClass('modal fade').appendTo(document.body)
+        .addClass('modal fade').appendTo(document.body).css(
+          'backgroundColor': 'white'
+          'margin': 'auto'
+          )
+      console.debug("Modal?", $('#cc-modal'))
 
 
       if @model.asPage()?.get('loaded') and @model.isDraft()

--- a/src/scripts/modules/media/body/body.coffee
+++ b/src/scripts/modules/media/body/body.coffee
@@ -8,18 +8,19 @@ define (require) ->
   SimModal = require('cs!./embeddables/modals/sims/sims')
   cc = require('OpenStaxReactComponents')
   template = require('hbs!./body-template')
+  settings = require('settings')
   require('less!./body')
 
   embeddableTemplates =
     'exercise': require('hbs!./embeddables/exercise-template')
     'iframe': require('hbs!./embeddables/iframe-template')
 
-  fakeExerciseTemplates = [
-    require('hbs!./embeddables/fake-exercises/ex001')
-    require('hbs!./embeddables/fake-exercises/ex002')
-    require('hbs!./embeddables/fake-exercises/ex003')
-    require('hbs!./embeddables/fake-exercises/ex004')
-  ]
+  # fakeExerciseTemplates = [
+  #   require('hbs!./embeddables/fake-exercises/ex001')
+  #   require('hbs!./embeddables/fake-exercises/ex002')
+  #   require('hbs!./embeddables/fake-exercises/ex003')
+  #   require('hbs!./embeddables/fake-exercises/ex004')
+  # ]
 
   return class MediaBodyView extends EditableView
     key = []
@@ -35,7 +36,8 @@ define (require) ->
 
         return @model.get('loaded')
       isCoach: ->
-        return true
+        moduleUUID = @model.getUuid()
+        _.contains(settings.conceptCoach.moduleUuids, moduleUUID)
 
     editable:
       '.media-body':
@@ -67,6 +69,7 @@ define (require) ->
         $els.hide()
 
     intializeConceptCoach: ->
+      return unless @templateHelpers.isCoach()
       $body = $('body')
 
       animatedScroll = (top) ->
@@ -78,7 +81,7 @@ define (require) ->
       handleClose = (eventData) ->
         cc.handleClosed(eventData, $body[0])
 
-      cc.init('http://localhost:3001')
+      cc.init(settings.conceptCoach.url)
       cc.on('ui.close', handleClose)
       cc.on('open', handleOpen)
 
@@ -89,7 +92,10 @@ define (require) ->
         collectionUUID = @model.getUuid()
         moduleUUID = @model.get('currentPage').getUuid()
 
-        cc.open($button.parent()[0], {collectionUUID, moduleUUID})
+        collectionVersion = @model.get('version')
+        moduleVersion = @model.get('currentPage').get('version')
+
+        cc.open($button.parent()[0], {collectionUUID, moduleUUID, collectionVersion, moduleVersion})
 
 
     # Toggle the visibility of teacher's edition elements

--- a/src/scripts/modules/media/body/body.coffee
+++ b/src/scripts/modules/media/body/body.coffee
@@ -6,7 +6,7 @@ define (require) ->
   EditableView = require('cs!helpers/backbone/views/editable')
   ProcessingInstructionsModal = require('cs!./processing-instructions/modals/processing-instructions')
   SimModal = require('cs!./embeddables/modals/sims/sims')
-  require('bootstrapModal')
+  cc = require('OpenStaxReactComponents')
   template = require('hbs!./body-template')
   require('less!./body')
 
@@ -52,6 +52,7 @@ define (require) ->
       'click .concept-coach-launcher > button': 'launchConceptCoach'
 
     initialize: () ->
+      cc.init('http://localhost:3001')
       super()
       @listenTo(@model, 'change:loaded', @render)
       @listenTo(@model, 'change:currentPage change:currentPage.active change:currentPage.loaded', @render)
@@ -66,10 +67,7 @@ define (require) ->
         $els.hide()
 
     launchConceptCoach: (event) ->
-      $modalDiv = $('#cc-modal')
-      $modalDiv.modal()
-      $modalDiv.modal('show')
-      console.debug("DIV:", $modalDiv)
+      cc.open(document.body, collectionUUID: 'd52e93f4-8653-4273-86da-3850001c0786', moduleUUID: '0c917d7d-0d1d-4a21-afbe-7d66bce2782c')
 
     # Toggle the visibility of teacher's edition elements
     toggleTeacher: () ->
@@ -367,13 +365,6 @@ define (require) ->
 
 
     onRender: () ->
-      $('<div id="cc-modal">').height('300px').width('600px').text('There is no I in TEAM')
-        .addClass('modal fade').appendTo(document.body).css(
-          'backgroundColor': 'white'
-          'margin': 'auto'
-          )
-      console.debug("Modal?", $('#cc-modal'))
-
 
       if @model.asPage()?.get('loaded') and @model.isDraft()
         @parent?.regions.self.append(new ProcessingInstructionsModal({model: @model}))

--- a/src/scripts/modules/media/body/body.coffee
+++ b/src/scripts/modules/media/body/body.coffee
@@ -67,7 +67,9 @@ define (require) ->
         $els.hide()
 
     launchConceptCoach: (event) ->
-      cc.open(document.body, collectionUUID: 'd52e93f4-8653-4273-86da-3850001c0786', moduleUUID: '0c917d7d-0d1d-4a21-afbe-7d66bce2782c')
+      collectionUUID = @model.getUuid()
+      moduleUUID = @model.get('currentPage').getUuid()
+      cc.open(document.body, {collectionUUID, moduleUUID})
 
     # Toggle the visibility of teacher's edition elements
     toggleTeacher: () ->

--- a/src/scripts/modules/media/body/body.less
+++ b/src/scripts/modules/media/body/body.less
@@ -69,11 +69,7 @@ body {
   .transition(background 0.5s ease-in-out);
 }
 
-
 body.cc-opened {
-  background: #e5e5e5;
-  overflow: hidden !important;
-
   .concept-coach-wrapper {
     margin-top: 2rem;
     text-align: left;
@@ -81,6 +77,5 @@ body.cc-opened {
     .concept-coach-view {
       max-width: 960px;
     }
-
   }
 }

--- a/src/scripts/modules/media/body/body.less
+++ b/src/scripts/modules/media/body/body.less
@@ -52,8 +52,35 @@
 
 .concept-coach-launcher {
   text-align: center;
-  button {
-    font-weight: bolder;
-    font-size: 1.5rem;
+  margin: 4rem 0;
+
+  > button {
+    font-size: 2rem;
+    letter-spacing: 0.5px;
+
+    .cc-logo {
+      text-transform: uppercase;
+    }
+  }
+}
+
+
+body {
+  .transition(background 0.5s ease-in-out);
+}
+
+
+body.cc-opened {
+  background: #e5e5e5;
+  overflow: hidden !important;
+
+  .concept-coach-wrapper {
+    margin-top: 2rem;
+    text-align: left;
+
+    .concept-coach-view {
+      max-width: 960px;
+    }
+
   }
 }

--- a/src/scripts/modules/media/body/body.less
+++ b/src/scripts/modules/media/body/body.less
@@ -49,3 +49,11 @@
     padding-left: 2rem;
   }
 }
+
+.concept-coach-launcher {
+  text-align: center;
+  button {
+    font-weight: bolder;
+    font-size: 1.5rem;
+  }
+}

--- a/src/scripts/settings.js
+++ b/src/scripts/settings.js
@@ -67,9 +67,10 @@
 
       conceptCoach: {
         moduleUuids: [
-          'f10533ca-f803-490d-b935-88899941197f'
+          'f10533ca-f803-490d-b935-88899941197f',
+          '8QUzyvgD'
         ],
-        url: 'https://tutor-dev.openstax.org/'
+        url: 'http://localhost:3001/'
       }
 
     };

--- a/src/scripts/settings.js
+++ b/src/scripts/settings.js
@@ -70,7 +70,7 @@
           'f10533ca-f803-490d-b935-88899941197f',
           '8QUzyvgD'
         ],
-        url: 'http://localhost:3001/'
+        url: 'https://tutor-dev.openstax.org'
       }
 
     };

--- a/src/scripts/settings.js
+++ b/src/scripts/settings.js
@@ -10,7 +10,7 @@
 
       // Hostname and port for the cnx-archive server
       cnxarchive: {
-        host: 'devarchive.cnx.org',
+        host: 'archive.cnx.org',
         port: 80
       },
 

--- a/src/scripts/settings.js
+++ b/src/scripts/settings.js
@@ -10,7 +10,7 @@
 
       // Hostname and port for the cnx-archive server
       cnxarchive: {
-        host: 'archive.cnx.org',
+        host: 'devarchive.cnx.org',
         port: 80
       },
 
@@ -63,6 +63,13 @@
 
       defaultLicense: {
         code: 'by'
+      },
+
+      conceptCoach: {
+        moduleUuids: [
+          'f10533ca-f803-490d-b935-88899941197f'
+        ],
+        url: 'https://tutor-dev.openstax.org/'
       }
 
     };

--- a/src/styles/main.less
+++ b/src/styles/main.less
@@ -1,5 +1,6 @@
 @import "@{dependencyDir}/bootstrap/less/bootstrap.less"; // Bootstrap
 @import "@{dependencyDir}/font-awesome/less/font-awesome.less"; // Font-Awesome
+@import "@{dependencyDir}/concept-coach/assets/main.css"; // Concept Coach
 @import "./variables.less";
 @import "./mixins-app.less";
 @import "./aloha-hacks.less"; // Aloha Hacks


### PR DESCRIPTION
![screen shot 2015-11-11 at 9 44 59 am](https://cloud.githubusercontent.com/assets/2483873/11095072/e8a5bf9e-8858-11e5-809b-7d9a9150b2ff.png)


Ready for review.  Will show concept coach button for book [`8QUzyvgD`](http://localhost:8000/contents/8QUzyvgD) -- linked to local at 8000.  The button should not show on other books.

Clicking on the link locally should trigger a request to tutor-dev but CORs will be denied.  The full widget will not work until on [dev.cnx.org](https://dev.cnx.org), and tutor-dev is also up and running.

Once it's working, CC should look like this: http://openstax.github.io/concept-coach/.