### PR TITLE
Fixes

### DIFF
--- a/src/scripts/helpers/links.coffee
+++ b/src/scripts/helpers/links.coffee
@@ -7,9 +7,10 @@ define (require) ->
   shortcodes = settings.shortcodes
   inverseShortcodes = _.invert(shortcodes)
 
-  return new class LinksHelper
-    contentsLinkRegEx: ///
-    ^contents/    # After contents/
+  # For interpolating into reg exps, it has to be a string without
+  # the surrounding slashes
+  contentPattern =
+    ///
     ([^:@/]+)     # uuid up to delimiter
     @?            # Optional @
     ([^:/?]*)     # Revision
@@ -18,7 +19,12 @@ define (require) ->
     /?            # Optional /
     ([^?]*)       # Segment of title
     (\?.*)?       # params (optional)
-    ///
+    ///.toString().slice(1, -1)
+
+  return new class LinksHelper
+    contentPattern: contentPattern
+
+    contentsLinkRegEx: ///^contents/#{contentPattern}///
 
     cleanUrl: trim
 

--- a/src/scripts/models/contents/collection.coffee
+++ b/src/scripts/models/contents/collection.coffee
@@ -45,7 +45,7 @@ define (require) ->
     _getPageId: (id) ->
       for node in @get('contents').models
         if node is id or node.get('id') is id or node.getVersionedId() is id or
-        node.get('shortId') is id
+        node.get('shortId').match(///^#{id}///)
           return node
         else if node.isSection()
           result = node.getPage(id)

--- a/src/scripts/models/contents/node.coffee
+++ b/src/scripts/models/contents/node.coffee
@@ -6,6 +6,7 @@ define (require) ->
   $ = require('jquery')
   Backbone = require('backbone')
   settings = require('settings')
+  linksHelper = require('cs!helpers/links')
   require('backbone-associations')
   session = require('cs!session')
 
@@ -167,7 +168,7 @@ define (require) ->
     # Utility Methods
     #
 
-    _getIdComponents: () -> @id?.match(/([^:@\/]+)@?([^:\/]*):?([0-9]*)\/?(.*)/)
+    _getIdComponents: -> @id?.match(///^#{linksHelper.contentPattern}///)
 
     getVersionedId: () ->
       components = @_getIdComponents() or []

--- a/src/scripts/modules/media/nav/nav.coffee
+++ b/src/scripts/modules/media/nav/nav.coffee
@@ -47,14 +47,14 @@ define (require) ->
     nextPage: (e) ->
       nextPage = @model.getNextPageNumber()
       # Show the next page if there is one
-      @model.setPage(nextPage)
       @changePage(e)
+      @model.setPage(nextPage)
 
     previousPage: (e) ->
       previousPage = @model.getPreviousPageNumber()
       # Show the previous page if there is one
-      @model.setPage(previousPage)
       @changePage(e)
+      @model.setPage(previousPage)
 
     changePage: (e) ->
       # Don't intercept cmd/ctrl-clicks intended to open a link in a new tab


### PR DESCRIPTION
Nav was updating model before changing pages
Separated short Id handler out so it isn’t called every render
node.coffee now uses regexp in linksHelper file; split pattern in
linksHelper so it can do that
finding the page by shortID works with or without version number