### PR TITLE
Ensures URL for content is canonical

### DIFF
--- a/src/scripts/helpers/links.coffee
+++ b/src/scripts/helpers/links.coffee
@@ -33,15 +33,18 @@ define (require) ->
 
       switch page
         when 'contents'
-          uuid = data.model.getVersionedId()
-          uuid = inverseShortcodes[uuid] if inverseShortcodes[uuid]
+          uuid = data.model.get('shortId')
+          version = data.model.get('version')
+          uuid += "@#{version}" if version?
           title = data.model.get('title')
           if data.model.isBook() and data.page?
             pageInfo = data.model._lookupPage(data.page)
-            pageId = pageInfo?.id ? data.page
+            pageId = pageInfo?.get('shortId') ? pageInfo?.id ? data.page
+            pageVersion = pageInfo?.get('version')
             title = pageInfo?.get('title')
           url += "contents/#{uuid}"
           url += ":#{pageId}" if pageId
+          url += "@#{pageVersion}" if pageVersion?
           url += "/#{trim(title)}" if title
 
       return url

--- a/test/scripts/helpers/links.js
+++ b/test/scripts/helpers/links.js
@@ -31,15 +31,24 @@ describe('links helper tests', function () {
           getVersionedId: function () {
             return 'not real';
           },
-          get: function () {
-            return 'page title';
+          get: function (which) {
+            switch (which) {
+              case 'shortId':
+                return 'shortId';
+              case 'version':
+                return 'version';
+              case 'title':
+                return 'title';
+              default:
+                return 'something';
+            }
           },
           isBook: function () {
             return false;
           }
         }
       };
-      links.getPath(page, data).should.equal('/contents/not real/page-title');
+      links.getPath(page, data).should.equal('/contents/shortId@version/title');
     });
     it('should append uuid and page title from settings to url', function () {
       var page = 'contents';
@@ -56,7 +65,7 @@ describe('links helper tests', function () {
           }
         }
       };
-      links.getPath(page, data).should.equal('/contents/college-physics/book-title');
+      links.getPath(page, data).should.equal('/contents/book title@book title/book-title');
     });
     it('should append uuid, book info and page title to url', function () {
       var page = 'contents';
@@ -81,7 +90,7 @@ describe('links helper tests', function () {
         },
         page: 'page'
       };
-      links.getPath(page, data).should.equal('/contents/college-physics:page/page-title');
+      links.getPath(page, data).should.equal('/contents/book name@book name:page title!@page title!/page-title');
     });
   });
   describe('serialize query tests', function () {


### PR DESCRIPTION
linksHelper.getPath now returns short-id@version for both book and
page, which covers all navigation links.
Content body checks that the URL matches the canonical path or updates
it if not.