### PR TITLE
Fix: Book/Page toggle for Metadata not displaying

### DIFF
--- a/src/scripts/modules/media/footer/metadata/metadata.less
+++ b/src/scripts/modules/media/footer/metadata/metadata.less
@@ -1,6 +1,10 @@
 @import "../../../../../styles/variables.less";
 @import "../../../../../styles/mixins.less";
 
+.metadata.tab-content > div {
+  position: relative;
+}
+
 .media-tabs .metadata {
   position: relative;
   padding: 5rem 4rem 3rem 4rem;


### PR DESCRIPTION
The CSS expected the container to have relative position.