### PR TITLE
Update in-book-search

### DIFF
--- a/src/scripts/models/contents/node.coffee
+++ b/src/scripts/models/contents/node.coffee
@@ -17,6 +17,9 @@ define (require) ->
 
   return class Node extends Backbone.AssociatedModel
     eTag: null
+    defaults: {
+      visible: true
+    }
 
     # url: () -> "#{SERVER}/contents/#{@id}"
     url: () ->

--- a/src/scripts/modules/media/body/body.less
+++ b/src/scripts/modules/media/body/body.less
@@ -40,9 +40,6 @@
   // Import the content styling from a separate file so it can be included in the editing code
   > #content {
     @import 'content.less';
-    .q-match {
-      background-color: yellow;
-    }
   }
 
   cnx-pi {

--- a/src/scripts/modules/media/header/header-template.html
+++ b/src/scripts/modules/media/header/header-template.html
@@ -18,7 +18,7 @@
         {{#is status 'publishing'}}
           <span class="label label-info">publishing</span>
         {{/is}}
-        {{currentPage.title}}
+        {{{pageTitle}}}
       </h2>
       {{#if currentPage.parent.id}}
         <span>

--- a/src/scripts/modules/media/header/header.coffee
+++ b/src/scripts/modules/media/header/header.coffee
@@ -31,6 +31,7 @@ define (require) ->
 
       return {
         currentPage: currentPage
+        pageTitle: currentPage.searchTitle ? currentPage.title
         hasDownloads: (_.isArray(downloads) and downloads?.length) or
           (_.isArray(pageDownloads) and pageDownloads?.length)
         derivable: @isDerivable()
@@ -78,6 +79,7 @@ define (require) ->
       @listenTo(@model, 'change:currentPage.editable change:currentPage.canPublish', @render)
       @listenTo(@model, 'change:currentPage', @updateTitle)
       @listenTo(router, 'navigate', @updatePageInfo)
+      @listenTo(@model, 'change:currentPage.searchTitle', @render)
 
     onRender: () ->
       if not @model.asPage()?.get('active') then return

--- a/src/scripts/modules/media/tabs/contents/contents.coffee
+++ b/src/scripts/modules/media/tabs/contents/contents.coffee
@@ -100,14 +100,13 @@ define (require) ->
       _.each pages, (page) ->
         page.unset('searchResult')
         page.unset('searchHtml')
+        page.unset('searchTitle')
         page.set('visible', not showingResults)
         expandContainers(page, false, showingResults)
       if pages? and showingResults
         _.each results, (result) ->
           resultId = result.id.replace(/@.*/, '')
-          snippet = result.headline.
-          replace(/<q-match>/g, '<span class="q-match">').
-          replace(/<\/q-match>/g, '</span>')
+          snippet = result.headline
           _.some pages, (page) ->
             pageId = page.id.replace(/@.*/, '')
             matched = (resultId == pageId)
@@ -129,19 +128,20 @@ define (require) ->
         bookId = "#{book.get('id')}@#{book.get('version')}"
         pageId = "#{page.get('id')}@#{page.get('version')}"
         BookSearchResults.fetch(
-          bookId: "#{bookId}/#{pageId}"
+          bookId: "#{bookId}:#{pageId}"
           query: response.query.search_term
         ).done((data) ->
           return unless data.results.items.length
-          html = data.results.items[0].html.replace(/<q-match>/g, '<span class="q-match">').
-          replace(/<\/q-match>/g, '</span class="q-match">')
-          $htmlNodes = $(html)
-          metaIndex = 0
-          # Heuristic: The actual content starts with a paragraph that has an id
-          ++metaIndex until $htmlNodes[metaIndex]?.id or metaIndex > $htmlNodes.length
-          $htmlNodes = $htmlNodes.slice(metaIndex)
-          html = $('<div>').append($htmlNodes).html()
+          html = data.results.items[0].html
+
+          # Adapted from models/contents/node.coffee; make a parseBody utility?
+          $body = $('<div>' + html.replace(/^[\s\S]*<body.*?>|<\/body>[\s\S]*$/g, '') + '</div>')
+          $title = $body.children('[data-type=document-title]').eq(0).remove()
+          $body.children('[data-type=abstract]').eq(0).remove()
+          html = $body.html()
+
           page.set('searchHtml', html)
+          page.set('searchTitle', $title.html())
         )
 
     onDragStart: (e) ->

--- a/src/scripts/modules/media/tabs/contents/toc/page.coffee
+++ b/src/scripts/modules/media/tabs/contents/toc/page.coffee
@@ -17,7 +17,7 @@ define (require) ->
         url: linksHelper.getPath('contents', {model: @content, page: pageNumber})
         editable: @editable
         searchResult: @model.get('searchResult')
-        visible: @model.get('visible') ? true
+        visible: @model.get('visible')
       }
 
     tagName: 'li'

--- a/src/scripts/modules/media/tabs/contents/toc/page.less
+++ b/src/scripts/modules/media/tabs/contents/toc/page.less
@@ -12,9 +12,6 @@
   a:hover {
     text-decoration: none;
   }
-  .q-match {
-    background-color: yellow;
-  }
 
   &:last-child {
     border-bottom: none;

--- a/src/scripts/modules/media/tabs/contents/toc/section.coffee
+++ b/src/scripts/modules/media/tabs/contents/toc/section.coffee
@@ -11,7 +11,7 @@ define (require) ->
     templateHelpers:
       editable: -> @editable
       visible: ->
-        @model.get('visible') ? true
+        @model.get('visible')
     itemViewContainer: '> ul'
 
     events:
@@ -35,7 +35,7 @@ define (require) ->
       @regions.container.empty()
       nodes = @model.get('contents')?.models
       _.each nodes, (node) =>
-        if node.get('visible') ? true
+        if node.get('visible')
           if node.isSection()
             @regions.container.appendAs 'li', new TocSectionView
               model: node

--- a/src/styles/main.less
+++ b/src/styles/main.less
@@ -12,7 +12,7 @@
   border: 0.2rem dotted #f00;
 }
 
-// Limit the site to a max width of 96rem
+// Limit the site width
 html {
   max-width: @max-viewport-width;
   margin: 0 auto;
@@ -99,6 +99,9 @@ h5, .extra-small-header {
   background-color: @brand-highlight;
 }
 
+.q-match {
+  background-color: yellow;
+}
 //
 // Buttons
 //


### PR DESCRIPTION
Change in API for BE
Made visible node attribute default to true
Use same body-parsing technique for search as node.coffee uses
Put .q-match style in main.less
Uses : instead of / in search API, needs to roll out with server change.