### PR TITLE
Back to toc

### DIFF
--- a/src/scripts/modules/media/nav/nav.coffee
+++ b/src/scripts/modules/media/nav/nav.coffee
@@ -52,7 +52,7 @@ define (require) ->
       'click .toggle.btn': 'toggleContents'
       'click .back-to-top > a': 'backToTop'
       'keydown .searchbar input': 'handleSearchInput'
-      'click .searchbar > .fa-close': 'clearSearch'
+      'click .searchbar > .clear-search': 'clearSearch'
 
     toggleContents: (e) ->
       @tocIsOpen = not @tocIsOpen
@@ -111,13 +111,13 @@ define (require) ->
       @$el.find('.searchbar input').val(@searchTerm)
       @model.unset('searchResults')
       @$el.find('.searchbar > .fa').
-      removeClass('fa-close').
+      removeClass('fa-times-circle clear-search').
       addClass('fa-search')
 
     enableClearSearch: ->
       @$el.find('.searchbar > .fa').
       removeClass('fa-search').
-      addClass('fa-close')
+      addClass('fa-times-circle clear-search')
 
     handleSearchInput: (event) ->
       if (event.keyCode == 13 and event.target.value?)

--- a/src/scripts/modules/media/nav/nav.less
+++ b/src/scripts/modules/media/nav/nav.less
@@ -56,7 +56,7 @@
         top: 0.3em;
         color: @gray-light;
         font-size: 150%;
-        &.fa-close {
+        &.clear-search {
           cursor: pointer;
         }
       }

--- a/src/scripts/modules/media/tabs/contents/contents-template.html
+++ b/src/scripts/modules/media/tabs/contents/contents-template.html
@@ -1,7 +1,7 @@
   {{#if editable}}
     <button type="button" class="add btn btn-default">Add <span class="caret"></span></button>
   {{/if}}
-
+  {{resultCount}}
   <div class="toc">
     {{! TocView}}
   </div>

--- a/src/scripts/modules/media/tabs/contents/contents-template.html
+++ b/src/scripts/modules/media/tabs/contents/contents-template.html
@@ -2,6 +2,7 @@
     <button type="button" class="add btn btn-default">Add <span class="caret"></span></button>
   {{/if}}
   {{resultCount}}
+  {{{clearResults}}}
   <div class="toc">
     {{! TocView}}
   </div>

--- a/src/scripts/modules/media/tabs/contents/contents.coffee
+++ b/src/scripts/modules/media/tabs/contents/contents.coffee
@@ -55,6 +55,10 @@ define (require) ->
         return unless hits?
         s = if hits is 1 then '' else 's'
         "#{hits} page#{s} matched"
+      clearResults: () ->
+        hits = @model?.get('searchResults')?.total
+        return unless hits?
+        '<br><a class="clear-results" href="#"><span class="fa fa-arrow-circle-left"></span>Back to Table of Contents</a>'
 
     regions:
       toc: '.toc'
@@ -62,6 +66,7 @@ define (require) ->
     events:
       'dragstart .toc [draggable]': 'onDragStart'
       'dragend .toc [draggable]': 'onDragEnd'
+      'click .clear-results': 'clearSearchResults'
 
     initialize: () ->
       super()
@@ -125,6 +130,10 @@ define (require) ->
               return matched
         @loadHighlightedPage()
       @render()
+
+    clearSearchResults: (event) ->
+      event.preventDefault();
+      @model.unset('searchResults')
 
     loadHighlightedPage: ->
       response = @model.get('searchResults')

--- a/src/scripts/modules/media/tabs/contents/contents.coffee
+++ b/src/scripts/modules/media/tabs/contents/contents.coffee
@@ -58,7 +58,13 @@ define (require) ->
       clearResults: () ->
         hits = @model?.get('searchResults')?.total
         return unless hits?
-        '<br><a class="clear-results" href="#"><span class="fa fa-arrow-circle-left"></span>Back to Table of Contents</a>'
+        '''
+        <br>
+        <a class="clear-results" href="#">
+          <span class="fa fa-arrow-circle-left"></span>
+          Back to Table of Contents
+        </a>
+        '''
 
     regions:
       toc: '.toc'
@@ -132,7 +138,7 @@ define (require) ->
       @render()
 
     clearSearchResults: (event) ->
-      event.preventDefault();
+      event.preventDefault()
       @model.unset('searchResults')
 
     loadHighlightedPage: ->


### PR DESCRIPTION
Added link that says "Back to Table of Contents" to search results; clicking it calls clearSearchResults function, leaving search term intact
Changed clear search icon to circle-times to match mockup
Used clear-search class so it’s not tied to particular icon