### PR TITLE
Change header hiding

### DIFF
--- a/src/scripts/modules/media/media.coffee
+++ b/src/scripts/modules/media/media.coffee
@@ -28,9 +28,8 @@ define (require) ->
   ###
   headerController = ($el, selector, compactSelector) ->
     threshold = window.innerHeight / 5
-    fudge = 8
     hideAbove = threshold
-    showBelow = fudge
+    showBelow = 8
     update = (event) ->
       return () ->
         Backbone.trigger 'window:resize'

--- a/src/scripts/modules/media/media.coffee
+++ b/src/scripts/modules/media/media.coffee
@@ -29,8 +29,8 @@ define (require) ->
   headerController = ($el, selector) ->
     threshold = window.innerHeight / 5
     fudge = 8
-    hideAbove = threshold + fudge
-    showBelow = threshold
+    hideAbove = threshold
+    showBelow = fudge
     update = (event) ->
       return () ->
         Backbone.trigger 'window:resize'

--- a/src/scripts/modules/media/media.coffee
+++ b/src/scripts/modules/media/media.coffee
@@ -26,7 +26,7 @@ define (require) ->
   items based on the scroll position. Attach the handler to
   a scroll event to hook it up.
   ###
-  headerController = ($el, selector) ->
+  headerController = ($el, selector, compactSelector) ->
     threshold = window.innerHeight / 5
     fudge = 8
     hideAbove = threshold
@@ -36,11 +36,14 @@ define (require) ->
         Backbone.trigger 'window:resize'
     return (event) ->
       $hideables = $el.find(selector)
+      $compactables = $el.find(compactSelector)
       top = $(event.target).scrollTop()
       if (top < showBelow and not $hideables.is(":visible"))
         $hideables.show(300, update(event))
+        $compactables.removeClass('compact')
       else if (top > hideAbove and $hideables.is(":visible"))
         $hideables.hide(300, update(event))
+        $compactables.addClass('compact')
 
   return class MediaView extends BaseView
     key = []
@@ -107,9 +110,9 @@ define (require) ->
       @mainContent = windowWithSidebar.regions.main
 
       hideThese = mediaTitleView.$el
-      headerHandler = headerController(hideThese, '.share')
+      headerHandler = headerController(hideThese, '.share', '.media-title')
       $('.fullsize-container .main').scroll(headerHandler)
-      mainHeaderHandler = headerController($('#header'), '>div')
+      mainHeaderHandler = headerController($('#header'), '>div', '.media-title')
       $('.fullsize-container .main').scroll(mainHeaderHandler)
 
     updateSummary: () ->

--- a/src/scripts/modules/media/media.coffee
+++ b/src/scripts/modules/media/media.coffee
@@ -23,26 +23,24 @@ define (require) ->
 
   ###
   Returns an event handler that will handle hiding and showing
-  items based on the scroll direction. Attach the handler to
+  items based on the scroll position. Attach the handler to
   a scroll event to hook it up.
   ###
   headerController = ($el, selector) ->
-    oldTop = 0
-    inTransition = false
+    threshold = window.innerHeight / 5
+    fudge = 8
+    hideAbove = threshold + fudge
+    showBelow = threshold
     update = (event) ->
       return () ->
-        oldTop = $(event.target).scrollTop()
         Backbone.trigger 'window:resize'
     return (event) ->
       $hideables = $el.find(selector)
       top = $(event.target).scrollTop()
-      return unless Math.abs(top - oldTop) > 5
-      if (top < oldTop and not $hideables.is(":visible"))
+      if (top < showBelow and not $hideables.is(":visible"))
         $hideables.show(300, update(event))
-      else if (top > oldTop and $hideables.is(":visible"))
+      else if (top > hideAbove and $hideables.is(":visible"))
         $hideables.hide(300, update(event))
-      else
-        oldTop = top
 
   return class MediaView extends BaseView
     key = []

--- a/src/scripts/modules/media/title/title.less
+++ b/src/scripts/modules/media/title/title.less
@@ -3,6 +3,13 @@
 
 .media-title {
   padding: 1rem 3rem;
+  &.compact {
+    padding: 0 3rem;
+    font-size: 85%;
+    .large-header {
+      font-size: 1.8rem;
+    }
+  }
 
   &:not(.publishing) { background-color: @gray-lightest; }
 


### PR DESCRIPTION
Only show header when scrolled to (almost) top. Hide header when scrolled down a portion of the window height. When hiding header, reduce title size.