### PR TITLE
Move findContentView to page code

### DIFF
--- a/src/scripts/pages/browse-content/browse-content.coffee
+++ b/src/scripts/pages/browse-content/browse-content.coffee
@@ -17,13 +17,11 @@ define (require) ->
     onRender: ->
       super()
       @$el.addClass('browse-content')
-      findContentView = new FindContentView()
-      findContentView.$el.insertBefore(@$el)
-      findContentView.render()
-
 
   return class BrowseContentView extends MainPageView
 
     onRender: () ->
       super()
-      @regions.main.show(new InnerView(@options))
+      findContentView = new FindContentView()
+      @regions.main.show(findContentView)
+      @regions.main.append(new InnerView(@options))


### PR DESCRIPTION
The way the Find Content bar was being inserted was causing it to
appear twice. Moving it allows me to use the standard region .show.