### PR TITLE
Keep header pinned after navigating

### DIFF
--- a/src/scripts/loader.coffee
+++ b/src/scripts/loader.coffee
@@ -1,4 +1,7 @@
 define (require) ->
+  # This needs to load first--at least for now--to ensure that styles in main is loaded before
+  # component specific styles.  This affects the order of the styles in the dist version.
+  require('less!../styles/main')
   $ = require('jquery')
   Backbone = require('backbone')
   settings = require('settings')
@@ -6,7 +9,6 @@ define (require) ->
   analytics = require('cs!helpers/handlers/analytics')
   router = require('cs!router')
   require('cs!helpers/backbone/history') # Extend Backbone.history to support query strings
-  require('less!../styles/main')
 
   RegExp.escape = (str) -> str.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&')
 

--- a/src/scripts/modules/media/body/body.coffee
+++ b/src/scripts/modules/media/body/body.coffee
@@ -459,6 +459,7 @@ define (require) ->
       _.each(sections, appendFakeExercise)
 
     onRender: () ->
+      @trigger('render')
       currentPage = @model.asPage()
       return unless currentPage?
       page = currentPage ? @model.get('contents')?.models[0]?.get('book')

--- a/src/scripts/modules/media/header/header.coffee
+++ b/src/scripts/modules/media/header/header.coffee
@@ -28,7 +28,7 @@ define (require) ->
 
       downloads = @model.get('downloads')
       pageDownloads = currentPage?.get?('downloads')
-      chapter = currentPage.chapter ? ''
+      chapter = currentPage.chapter ? currentPage._parent?.get('chapter') ? ''
 
       return {
         currentPage: currentPage

--- a/src/scripts/modules/media/media.coffee
+++ b/src/scripts/modules/media/media.coffee
@@ -79,7 +79,8 @@ define (require) ->
       windowWithSidebar.regions.main.append(mainPage)
       mainPage.regions.main.append(new MediaHeaderView({model: @model}))
       windowWithSidebar.regions.sidebar.append(tocView)
-      mainPage.regions.main.append(new MediaBodyView({model: @model}))
+      mediaBodyView = new MediaBodyView({model: @model})
+      mainPage.regions.main.append(mediaBodyView)
       mainPage.regions.main.append(new MediaFooterView({model: @model}))
       mainPage.regions.main.append(footerNav)
       footerNav.$el.addClass('footer-nav')
@@ -135,6 +136,14 @@ define (require) ->
             $(window).scrollTop(pinnableTop + 10)
         setTocHeight()
         )
+      wasPinnedAtChange = false
+      @model.on('change:currentPage', ->
+        wasPinnedAtChange = isPinned
+      )
+      mediaBodyView.on('render', ->
+        scrollTo = if wasPinnedAtChange then pinnableTop + 1 else 0
+        $(window).scrollTop(scrollTo)
+      )
 
     updateSummary: () ->
       abstract = @model.get('abstract')

--- a/src/scripts/modules/media/nav/nav.coffee
+++ b/src/scripts/modules/media/nav/nav.coffee
@@ -101,7 +101,6 @@ define (require) ->
       e.stopPropagation()
       href = $(e.currentTarget).attr('href')
       router.navigate href, {trigger: false}, () => @mediaParent.trackAnalytics()
-      $(window).scrollTop(0)
 
     closeContentsOnSmallScreen: ->
       if window.innerWidth < 640

--- a/src/scripts/modules/media/tabs/contents/toc/section.coffee
+++ b/src/scripts/modules/media/tabs/contents/toc/section.coffee
@@ -44,11 +44,11 @@ define (require) ->
         @$el.removeClass('active-container')
 
     onRender: () ->
+      @handleActiveContainer()
       return if @model.get('visible') == false
       super()
       return unless @regions
       @regions.container.empty()
-      @handleActiveContainer()
       nodes = @model.get('contents')?.models
       _.each nodes, (node) =>
         if node.get('visible')


### PR DESCRIPTION
If header was in hidden/compact mode before page change, the window will scroll there after.
Also, Introduction pages will display chapter numbers by their titles (but TOC still will not)
Fixes 1284