### PR TITLE
moves cc launcher to inside content, after review, but before glossary

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -23,7 +23,7 @@
     "require-handlebars-plugin": "1.0.0",
     "aloha-editor": "oerpub/Aloha-Editor#master",
     "select2": "3.5.4",
-    "concept-coach": "openstax/concept-coach#95fc1a0d0b8bdc154e5bb43c9f8219bdbc8f0d9e"
+    "concept-coach": "openstax/concept-coach#21d8129bf03f22d72de9b6fcaf8d99f30c20d4c7"
   },
   "devDependencies": {
     "chai": "3.2.0",

--- a/src/scripts/modules/media/body/body-template.html
+++ b/src/scripts/modules/media/body/body-template.html
@@ -8,11 +8,6 @@
         {{include content}}
       </div>
     </div>
-    {{#if isCoach}}
-    <div class="concept-coach-launcher">
-      <button type="button" class="btn">Open <span class="cc-logo"><strong>Concept</strong>Coach</span></button>
-    </div>
-    {{/if}}
   {{/if}}
 {{else}}
   <div class="media-body" aria-busy="true">

--- a/src/scripts/modules/media/body/body.coffee
+++ b/src/scripts/modules/media/body/body.coffee
@@ -15,6 +15,7 @@ define (require) ->
   embeddableTemplates =
     'exercise': require('hbs!./embeddables/exercise-template')
     'iframe': require('hbs!./embeddables/iframe-template')
+    'cc-launcher': require('hbs!./embeddables/cc-launcher-template')
 
   return class MediaBodyView extends EditableView
     key = []
@@ -240,6 +241,9 @@ define (require) ->
             hiddenSelectors = hiddenClasses.map((name) -> ".#{name}").join(', ')
             $exercisesToHide = $temp.find(hiddenSelectors)
             $exercisesToHide.add($exercisesToHide.siblings('[data-type=title]')).hide()
+
+            if @templateHelpers.isCoach.call(@)
+              $(embeddableTemplates['cc-launcher']()).insertAfter(_.last($exercisesToHide))
 
           @initializeEmbeddableQueues()
           @findEmbeddables($temp.find('#content'))

--- a/src/scripts/modules/media/body/content.less
+++ b/src/scripts/modules/media/body/content.less
@@ -24,7 +24,7 @@ p {
   }
 }
 
-a {
+a:not([role=button]) {
   text-decoration: underline;
 }
 

--- a/src/scripts/modules/media/body/embeddables/cc-launcher-template.html
+++ b/src/scripts/modules/media/body/embeddables/cc-launcher-template.html
@@ -1,0 +1,3 @@
+<div class="concept-coach-launcher">
+  <button type="button" class="btn">Open <span class="cc-logo"><strong>Concept</strong>Coach</span></button>
+</div>


### PR DESCRIPTION
![screen shot 2015-12-07 at 12 27 31 pm](https://cloud.githubusercontent.com/assets/2483873/11635698/f790cf28-9cdd-11e5-9517-ef17d31bb351.png)
