### PR TITLE
only handle cc resize when cc is opened

### DIFF
--- a/src/scripts/modules/media/body/body.coffee
+++ b/src/scripts/modules/media/body/body.coffee
@@ -113,7 +113,7 @@ define (require) ->
       )
 
       Backbone.on('window:optimizedResize', =>
-        @cc.handleResize()
+        @cc?.handleResize?()
       )
 
     updateCCOptions: ->


### PR DESCRIPTION
trying to call cc's handle resize on pages without a mounted cc was causing errors.