### PR TITLE
Coach with urls

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -23,7 +23,7 @@
     "require-handlebars-plugin": "1.0.0",
     "aloha-editor": "oerpub/Aloha-Editor#master",
     "select2": "3.5.4",
-    "concept-coach": "openstax/concept-coach#3817bb2050ddd8c026c96b071ed60984c50d66d1"
+    "concept-coach": "openstax/concept-coach#4cdb9693485825d3c3c6509197e3ebcc54f8fb16"
   },
   "devDependencies": {
     "chai": "3.2.0",

--- a/src/scripts/helpers/links.coffee
+++ b/src/scripts/helpers/links.coffee
@@ -28,7 +28,7 @@ define (require) ->
 
     cleanUrl: trim
 
-    getPath: (page, data) ->
+    getPath: (page, data, paramsToIgnore = ['cc-view']) ->
       url = settings.root
 
       switch page
@@ -46,7 +46,7 @@ define (require) ->
           url += ":#{pageId}" if pageId
           url += "@#{pageVersion}" if pageVersion?
           url += "/#{trim(title)}" if title
-          url += window.location.search
+          url += @getCleanSearchQuery(window.location.search, paramsToIgnore)
 
       return url
 
@@ -62,6 +62,18 @@ define (require) ->
         page = ":#{model.getPageNumber()}"
 
       return "#{settings.root}contents/#{id}#{page}/#{title}"
+
+    getCleanSearchQuery: (queryString, paramsToIgnore) ->
+      queryString ?= window.location.search
+
+      return queryString if _.isEmpty(paramsToIgnore)
+
+      query = @serializeQuery(queryString)
+
+      cleanedQuery = _.omit(query, paramsToIgnore)
+      cleanedQueryString = @param(cleanedQuery)
+
+      if _.isEmpty(cleanedQuery) then '' else "?#{@param(cleanedQuery)}"
 
     getCurrentPathComponents: () ->
       components = Backbone.history.fragment.match(@contentsLinkRegEx) or []

--- a/src/scripts/modules/media/body/embeddables/cc-launcher-template.html
+++ b/src/scripts/modules/media/body/embeddables/cc-launcher-template.html
@@ -1,3 +1,0 @@
-<div class="concept-coach-launcher">
-  <button type="button" class="btn">Open <span class="cc-logo"><strong>Concept</strong>Coach</span></button>
-</div>


### PR DESCRIPTION
includes:
* opening coach changes urls
  * such that when you click back while coach is opened, it closes the coach and leaves you back on the same page you launched the coach from
  * cnx nav links ignore the coach view query parameter by default, so that the cnx page nav for back and next navigates to the destination page with the coach closed
* taking the coach mounting out of a deferred
* clean up the `isCoach` -- no need for it to be a template helper anymore

Will be followed up by an update to the coach version after openstax/concept-coach#104 is merged, although this PR can be merged independent of a coach update