### PR TITLE
Handle no-pages condition

### DIFF
--- a/src/scripts/models/content.coffee
+++ b/src/scripts/models/content.coffee
@@ -106,6 +106,7 @@ define (require) ->
         @trigger("change:currentPage.#{eventName.slice(7)}", page, value)
 
     _setPage: (page) ->
+      return if @cachedPages.length == 0
       @set('error', 404) if not page?
       currentPage = @get('currentPage')
 

--- a/src/scripts/settings.js
+++ b/src/scripts/settings.js
@@ -10,7 +10,7 @@
 
       // Hostname and port for the cnx-archive server
       cnxarchive: {
-        host: 'devarchive.cnx.org',
+        host: 'archive.cnx.org',
         port: 80
       },
 

--- a/src/scripts/settings.js
+++ b/src/scripts/settings.js
@@ -10,7 +10,7 @@
 
       // Hostname and port for the cnx-archive server
       cnxarchive: {
-        host: 'archive.cnx.org',
+        host: 'devarchive.cnx.org',
         port: 80
       },
 


### PR DESCRIPTION
If book contains no pages, don’t 404 in setPage, just return.

Fixes #1335