### PR TITLE
Restore legacy login link to main pages

### DIFF
--- a/src/scripts/modules/header/header.less
+++ b/src/scripts/modules/header/header.less
@@ -14,10 +14,14 @@
   border-bottom: 2px solid @gray-lighter;
 
   > .login {
-    padding: 1.5rem 1.5rem 0 0;
+    padding: 1rem 1.5rem 0 0;
     font-size: 0.9em;
     font-weight: 300;
     text-align: right;
+
+    > ul {
+      margin-bottom: 0;
+    }
 
     > #skiptocontent,
     > #skiptoresults {

--- a/src/scripts/pages/app/app.coffee
+++ b/src/scripts/pages/app/app.coffee
@@ -35,6 +35,7 @@ define (require) ->
       if queryString.minimal
         @minimal = true
       headerView = if @minimal then new MinimalHeaderView() else new HeaderView()
+      headerView.setLegacyLink('content')
       @regions.header.show(headerView)
       # Lazy-load the page
       require ["cs!pages/#{page}/#{page}"], (View) =>


### PR DESCRIPTION
Lost the login link with the donate button. Restored.
Tightened up the spacing a bit