### PR TITLE
Handle scroll-to-anchor in content

### DIFF
--- a/src/scripts/modules/media/media.coffee
+++ b/src/scripts/modules/media/media.coffee
@@ -98,10 +98,18 @@ define (require) ->
         newHeight = window.innerHeight - tocTop
         $toc.height("#{newHeight}px")
       Backbone.on('window:optimizedResize', setTocHeight)
+      adjustHashTop = ->
+        handleHeaderViewPinning()
+        if isPinned
+          obscured = $pinnable.height()
+          top = $(window.location.hash).position().top
+          $(window).scrollTop(top - obscured)
+      Backbone.on('window:hashChange', adjustHashTop)
 
       # closing is triggered in 'onBeforeClose'
       @on('closing', ->
         Backbone.off('window:optimizedResize', setTocHeight)
+        Backbone.off('window:hashChange', adjustHashTop)
       )
 
       adjustMainMargin = (height) ->

--- a/src/scripts/modules/media/tabs/contents/contents.coffee
+++ b/src/scripts/modules/media/tabs/contents/contents.coffee
@@ -69,7 +69,6 @@ define (require) ->
       'dragstart .toc [draggable]': 'onDragStart'
       'dragend .toc [draggable]': 'onDragEnd'
       'click .clear-results': 'clearSearchResults'
-      'scroll': 'saveScrollPosition'
 
     initialize: () ->
       super()
@@ -87,10 +86,8 @@ define (require) ->
       @regions.self.append new AddPopoverView
         model: @model
         owner: @$el.find('.add.btn')
-      @$el.scrollTop(@scrollPosition)
 
-    saveScrollPosition: ->
-      @scrollPosition = @$el.scrollTop()
+
 
     processPages: ->
       nodes = @model.get('contents')?.models

--- a/src/scripts/pages/app/app.coffee
+++ b/src/scripts/pages/app/app.coffee
@@ -29,6 +29,9 @@ define (require) ->
         Backbone.trigger('window:optimizedScroll')
       , throttleTime))
 
+      window.onhashchange = (arg...) ->
+        Backbone.trigger('window:hashChange')
+
     render: (page, options) ->
       queryString = linksHelper.serializeQuery(location.search)
       @minimal = false


### PR DESCRIPTION
Pinned navbar obscures top of window, so when going to id, scroll back
by the height of the bar.
Removed some old scrolling code for element that no longer scrolls
Fixes #1344