### PR TITLE
Fix toc editor

### DIFF
--- a/src/scripts/models/content.coffee
+++ b/src/scripts/models/content.coffee
@@ -107,7 +107,9 @@ define (require) ->
 
     _setPage: (page) ->
       return if @cachedPages.length == 0
-      @set('error', 404) if not page?
+      if not page?
+        @set('error', 404)
+        console.error("Setpage error")
       currentPage = @get('currentPage')
 
       if currentPage

--- a/src/scripts/models/contents/collection.coffee
+++ b/src/scripts/models/contents/collection.coffee
@@ -59,12 +59,13 @@ define (require) ->
         page.get('shortId')?.match(idPattern)
           return page
 
-      return
+      return new Page({id: id})
 
     getPage: (page) ->
+      if page instanceof Page
+        return page
       if typeof page is 'number'
         return @_getPageNum(page)
-
       return @_getPageFromId(page)
 
     toJSON: (options = {}) ->

--- a/src/scripts/models/contents/node.coffee
+++ b/src/scripts/models/contents/node.coffee
@@ -135,7 +135,7 @@ define (require) ->
     containers: ->
       result = []
       parent = @get('_parent')
-      while parent.isSection()
+      while parent?.isSection()
         result.push(parent)
         parent = parent.get('_parent')
       result

--- a/src/scripts/modules/media/header/header.coffee
+++ b/src/scripts/modules/media/header/header.coffee
@@ -76,7 +76,7 @@ define (require) ->
 
       @listenTo(@model, 'change:downloads change:buyLink change:title change:active', @render)
       @listenTo(@model, 'change:currentPage change:currentPage.active change:currentPage.loaded', @render)
-      @listenTo(@model, 'change:abstract change:currentPage.abstract', @render)
+      @listenTo(@model, 'change:abstract change:currentPage.abstract change:currentPage.chapter', @render)
       @listenTo(session, 'change', @render)
       @listenTo(@model, 'change:currentPage.editable change:currentPage.canPublish', @render)
       @listenTo(@model, 'change:currentPage', @updateTitle)

--- a/src/scripts/modules/media/nav/nav.coffee
+++ b/src/scripts/modules/media/nav/nav.coffee
@@ -65,7 +65,7 @@ define (require) ->
       @.trigger('tocIsOpen', @tocIsOpen)
       if @tocIsOpen
         @closeAllContainers() unless @model.get('searchResults')
-        for container in @model.get('currentPage').containers()
+        for container in @model.get('currentPage')?.containers() ? []
           container.set('expanded', true)
       @updateToc()
 

--- a/src/scripts/modules/media/tabs/contents/contents.coffee
+++ b/src/scripts/modules/media/tabs/contents/contents.coffee
@@ -72,7 +72,8 @@ define (require) ->
 
     initialize: () ->
       super()
-      @listenTo(@model, 'change:editable removeNode moveNode change:currentPage', _.debounce(@render, 250))
+      @listenTo(@model, 'removeNode addNode moveNode', @processPages)
+      @listenTo(@model, 'change:editable change:currentPage addNode removeNode moveNode', _.debounce(@render, 250))
       @listenTo(@model, 'change:contents add:contents remove:contents', _.debounce(@processPages, 250))
       @listenTo(@model, 'change:searchResults', @handleSearchResults)
       @listenTo(@model, 'change:currentPage', @loadHighlightedPage)
@@ -179,3 +180,4 @@ define (require) ->
 
       # Reset styling for all draggable elements
       e.currentTarget.className = ''
+      @model.trigger('moveNode')

--- a/src/scripts/modules/media/tabs/contents/popovers/add/modals/add-page.coffee
+++ b/src/scripts/modules/media/tabs/contents/popovers/add/modals/add-page.coffee
@@ -211,8 +211,8 @@ define (require) ->
       else
         _.each data, (input) =>
           if input.name isnt 'title'
-            @model.add({id: input.name, title: input.value})
-            @model.setPage(input.name)
+            added = @model.add({id: input.name, title: input.value})
+            @model.setPage(added)
             @updateUrl()
 
       $('.modal-backdrop').remove() # HACK: Ensure bootstrap modal backdrop is removed


### PR DESCRIPTION
Fix remaining issues with TOC editing:
- getPage was being called on Page objects and not simply returning the object
- already-published pages would not insert into TOC
- after adding, last added page should become current page
- chapters were not being renumbered when TOC was re-arranged