### PR TITLE
Rollback cc

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -3,6 +3,7 @@ module.exports = (grunt) ->
   fs = require('fs')
   pkg = require('./package.json')
 
+  ###
   alohaBuildConfig = grunt.file.read('bower_components/aloha-editor/build/aloha/build-profile-with-oer.js')
   alohaBuildConfig = eval(alohaBuildConfig)
   alohaBuildConfig.appDir = 'bower_components/aloha-editor/src/'
@@ -17,6 +18,7 @@ module.exports = (grunt) ->
   alohaBuildConfig.optimizeCss = "standard"
   alohaBuildConfig.separateCSS = false
   alohaBuildConfig.preserveLicenseComments = false
+  ###
 
   # Project configuration.
   grunt.initConfig
@@ -25,11 +27,13 @@ module.exports = (grunt) ->
     # Development nginx server
     # ----
     # Start with `grunt nginx:start`
+    ###
     nginx:
       tasks: ['nginx']
       options:
         config: 'nginx.development.conf'
         prefix: './'
+    ###
 
     # Lint
     # ----
@@ -148,20 +152,20 @@ module.exports = (grunt) ->
               'cs!pages/contents/contents'
               'cs!pages/search/search'
               'cs!pages/browse-content/browse-content'
-              'cs!pages/workspace/workspace'
+              #'cs!pages/workspace/workspace'
               'cs!pages/about/about'
               'cs!pages/tos/tos'
               'cs!pages/license/license'
               'cs!pages/donate/donate'
-              'cs!pages/role-acceptance/role-acceptance'
+              #'cs!pages/role-acceptance/role-acceptance'
 
               # FIX: edit modules should be loaded in separate modules
-              'select2'
-              'bootstrapPopover'
-              'cs!modules/media/editbar/editbar'
+              #'select2'
+              #'bootstrapPopover'
+              #'cs!modules/media/editbar/editbar'
               'cs!helpers/backbone/views/editable'
 
-              'cs!configs/aloha'
+              #'cs!configs/aloha'
             ]
             exclude: ['coffee-script', 'less/normalize']
             excludeShallow: ['settings']
@@ -177,8 +181,8 @@ module.exports = (grunt) ->
 
             done()
 
-      aloha:
-        options: alohaBuildConfig
+      #aloha:
+      #  options: alohaBuildConfig
 
     # Target HTML
     targethtml:
@@ -191,9 +195,9 @@ module.exports = (grunt) ->
       require:
         src: 'bower_components/requirejs/require.js'
         dest: 'dist/scripts/require.js'
-      aloha:
-        src: 'bower_components/aloha-editor/target/build-profile-with-oer/rjs-output/lib/aloha.js'
-        dest: 'dist/scripts/aloha.js'
+      #aloha:
+      #  src: 'bower_components/aloha-editor/target/build-profile-with-oer/rjs-output/lib/aloha.js'
+      #  dest: 'dist/scripts/aloha.js'
       fonts:
         expand: true
         filter: 'isFile'
@@ -261,6 +265,7 @@ module.exports = (grunt) ->
         }]
 
     # String Replace (HACK to update aloha path)
+    ###
     'string-replace':
       dist:
         options:
@@ -270,6 +275,7 @@ module.exports = (grunt) ->
           }]
         files:
           'dist/scripts/main.js': ['dist/scripts/main.js']
+    ###
 
     test:
       options:
@@ -313,16 +319,16 @@ module.exports = (grunt) ->
 
   # Aloha
   # -----
-  grunt.registerTask 'aloha', [
-    'requirejs:aloha'
-  ]
+  #grunt.registerTask 'aloha', [
+  #  'requirejs:aloha'
+  #]
 
   # Dist
   # -----
   grunt.registerTask 'dist', [
     'requirejs:compile'
     'copy'
-    'string-replace'
+    #'string-replace'
     'targethtml:dist'
     'clean'
     'uglify:dist'

--- a/bower.json
+++ b/bower.json
@@ -23,7 +23,7 @@
     "require-handlebars-plugin": "1.0.0",
     "aloha-editor": "oerpub/Aloha-Editor#master",
     "select2": "3.5.4",
-    "concept-coach": "openstax/concept-coach#d-2016-01-20-c"
+    "concept-coach": "openstax/concept-coach#98dddd9b33bc509b72309ef14ba3ee698e5731a9"
   },
   "devDependencies": {
     "chai": "3.2.0",

--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "version": "0.19.1-dev",
   "description": "Connexions (cnx.org) web site",
   "scripts": {
-    "prepublish": "bower install --config.analytics=false; grunt aloha --verbose",
-    "upgrade": "npm update; bower update --config.analytics=false; grunt aloha --verbose",
+    "prepublish": "bower install --config.analytics=false",
+    "upgrade": "npm update; bower update --config.analytics=false",
     "test": "grunt test --verbose",
     "dist": "grunt dist --verbose"
   },
@@ -31,7 +31,6 @@
     "grunt-string-replace": "~1.2.0",
     "less": "~1.7.5",
     "csso": "~1.3.11",
-    "grunt-nginx": "~0.2.2",
     "grunt-mocha": "~0.4.11"
   },
   "license": [

--- a/src/scripts/modules/header/header-template.html
+++ b/src/scripts/modules/header/header-template.html
@@ -12,10 +12,6 @@
       </div>
     {{/if}}
     <ul>
-      {{#if username}}
-        <li><a data-bypass="true" href="{{accountProfile}}">Account Profile</a></li>
-        <li><a data-bypass="true" href="/logout">Log Out {{username}}</a></li>
-      {{/if}}
       {{#if url}}
         <li><a href="{{url}}" title="Switch to the CNX legacy web site">CNX Author | Legacy Site</a></li>
       {{/if}}
@@ -41,7 +37,6 @@
           <li {{#is page 'browse'}}class="active"{{/is}}><a href="/browse">Search</a></li>
           <li {{#is page 'about'}}class="active"{{/is}}><a href="/about">About Us</a></li>
           <li {{#is page 'donate'}}class="active"{{/is}}><a href="/donate">Give</a></li>
-          <li {{#is page 'workspace'}}class="active"{{/is}}><a href="/workspace">My Workspace</a></li>
           <li>
             <a href="http://www.rice.edu">
               <img src="/images/rice.png" class="rice" alt="Rice University" width="74" height="32" />

--- a/src/scripts/modules/media/body/body-template.html
+++ b/src/scripts/modules/media/body/body-template.html
@@ -3,7 +3,7 @@
 {{#if loaded}}
   {{#if hasContent}}
     {{! set id because Aloha's semanticblock hardcodes this id }}
-    <div class="media-body {{#if editable}}draft{{/if}} {{#is status 'publishing'}}publishing{{/is}}">
+    <div class="media-body">
       <div id="content">
         {{include content}}
       </div>

--- a/src/scripts/modules/media/body/body.coffee
+++ b/src/scripts/modules/media/body/body.coffee
@@ -39,8 +39,8 @@ define (require) ->
       'click a': 'changePage'
       'click [data-type="solution"] > .ui-toggle-wrapper > .ui-toggle,
         .solution > .ui-toggle-wrapper > .ui-toggle': 'toggleSolution'
-      'keydown .media-body': 'checkKeySequence'
-      'keyup .media-body': 'resetKeySequence'
+      #'keydown .media-body': 'checkKeySequence'
+      #'keyup .media-body': 'resetKeySequence'
       'click .os-interactive-link': 'simLink'
 
     regions:
@@ -397,20 +397,21 @@ define (require) ->
     ###
 
     fakeExercises: ($parent) ->
-      sections = $parent.find('section[data-depth="1"]')
+      return
+      #sections = $parent.find('section[data-depth="1"]')
 
-      appendFakeExercise = (section, iter) ->
-        $(section).append(fakeExerciseTemplates[iter % fakeExerciseTemplates.length])
+      #appendFakeExercise = (section, iter) ->
+      #  $(section).append(fakeExerciseTemplates[iter % fakeExerciseTemplates.length])
 
-      _.each(sections, appendFakeExercise)
+      #_.each(sections, appendFakeExercise)
 
     onRender: () ->
       @trigger('render')
       currentPage = @model.asPage()
       return unless currentPage?
       page = currentPage ? @model.get('contents')?.models[0]?.get('book')
-      if currentPage.get('loaded') and @model.isDraft()
-        @parent?.regions.self.append(new ProcessingInstructionsModal({model: @model}))
+      #if @model.asPage()?.get('loaded') and @model.isDraft()
+      #  @parent?.regions.self.append(new ProcessingInstructionsModal({model: @model}))
 
       return unless currentPage.get('active')
       if @model.get('sims') is true
@@ -465,21 +466,23 @@ define (require) ->
       @render() # Re-render body view to cleanup aloha issues
 
     checkKeySequence: (e) ->
-      key[e.keyCode] = true
-      if @model.isDraft()
+      return
+      #key[e.keyCode] = true
+      #if @model.isDraft()
         #ctrl+alt+shift+p+i
-        if key[16] and key[17] and key[18] and key[73] and key[80]
-          instructionTags = []
-          processingInstructions = @$el.find('.media-body').find('cnx-pi')
+      #  if key[16] and key[17] and key[18] and key[73] and key[80]
+      #    instructionTags = []
+      #    processingInstructions = @$el.find('.media-body').find('cnx-pi')
 
-          _.each processingInstructions, (instruction) ->
-            instructionTags.push(instruction.outerHTML)
+      #    _.each processingInstructions, (instruction) ->
+      #      instructionTags.push(instruction.outerHTML)
 
-          $('#pi').val(instructionTags.join('\n'))
-          $('#processing-instructions-modal').modal('show')
+      #    $('#pi').val(instructionTags.join('\n'))
+      #    $('#processing-instructions-modal').modal('show')
 
     resetKeySequence: (e) ->
-      key[e.keyCode] = false
+      return
+      #key[e.keyCode] = false
 
     simLink: (evt) ->
       evt.preventDefault()

--- a/src/scripts/modules/media/media.coffee
+++ b/src/scripts/modules/media/media.coffee
@@ -34,14 +34,14 @@ define (require) ->
     regions:
       media: '.media'
       pinnable: '.pinnable'
-      editbar: '.editbar'
+      #editbar: '.editbar'
 
     summary:() -> @updateSummary()
     description: () -> @updateDescription()
 
-    events:
-      'keydown .media-title > .title input': 'checkKeySequence'
-      'keyup .media-title > .title input': 'resetKeySequence'
+    #events:
+      #'keydown .media-title > .title input': 'checkKeySequence'
+      #'keyup .media-title > .title input': 'resetKeySequence'
 
     initialize: (options) ->
       super()
@@ -59,7 +59,7 @@ define (require) ->
         @listenTo(@model, 'change:legacy_id change:legacy_version change:currentPage
           change:currentPage.loaded', @updateLegacyLink)
       @listenTo(@model, 'change:error', @displayError)
-      @listenTo(@model, 'change:editable', @toggleEditor)
+      #@listenTo(@model, 'change:editable', @toggleEditor)
       @listenTo(@model, 'change:title change:currentPage change:currentPage.loaded', @updateUrl)
       @listenTo(@model, 'change:title change:currentPage change:currentPage.loaded', @updatePageInfo)
       @listenTo(@model, 'change:abstract', @updateSummary)
@@ -225,33 +225,37 @@ define (require) ->
 
     # FIX: How much of loadEditor and closeEditor can be merged into the editbar?
     loadEditor: () ->
-      @editing = true
+      return
+      #@editing = true
 
-      require ['cs!./editbar/editbar'], (EditbarView) =>
-        @regions.editbar.show(new EditbarView({model: @model}))
-        height = @regions.editbar.$el.find('.navbar').outerHeight()
-        $('body').css('padding-top', height) # Don't cover the page header
-        window.scrollBy(0, height) # Prevent viewport from jumping
+      #require ['cs!./editbar/editbar'], (EditbarView) =>
+      #  @regions.editbar.show(new EditbarView({model: @model}))
+      #  height = @regions.editbar.$el.find('.navbar').outerHeight()
+      #  $('body').css('padding-top', height) # Don't cover the page header
+      #  window.scrollBy(0, height) # Prevent viewport from jumping
 
     closeEditor: () ->
-      @editing = false
-      height = @regions.editbar.$el.find('.navbar').outerHeight()
-      @regions.editbar.empty()
-      $('body').css('padding-top', '0') # Remove added padding
-      window.scrollBy(0, -height) # Prevent viewport from jumping
+      return
+      #@editing = false
+      #height = @regions.editbar.$el.find('.navbar').outerHeight()
+      #@regions.editbar.empty()
+      #$('body').css('padding-top', '0') # Remove added padding
+      #window.scrollBy(0, -height) # Prevent viewport from jumping
 
     onBeforeClose: () ->
-      if @model.get('editable')
-        @model.set('editable', false, {silent: true})
-        @closeEditor()
+      #if @model.get('editable')
+      #  @model.set('editable', false, {silent: true})
+      #  @closeEditor()
       @trigger('closing')
 
     checkKeySequence: (e) ->
-      key[e.keyCode] = true
+      return
+      #key[e.keyCode] = true
       #ctrl+alt+shift+l+i
-      if key[16] and key[17] and key[18] and key[73] and key[76]
-        if @model.get('canChangeLicense') or @model.get('derivedFrom') is null
-          $('#license-modal').modal('show')
+      #if key[16] and key[17] and key[18] and key[73] and key[76]
+      #  if @model.get('canChangeLicense') or @model.get('derivedFrom') is null
+      #    $('#license-modal').modal('show')
 
     resetKeySequence: (e) ->
-      key[e.keyCode] = false
+      return
+      #key[e.keyCode] = false

--- a/src/scripts/modules/media/tabs/tabs-template.html
+++ b/src/scripts/modules/media/tabs/tabs-template.html
@@ -1,21 +1,17 @@
-<div class="media-tabs{{#is status 'publishing'}} publishing{{/is}}">
-  <ul role="tablist">
+<div class="media-tabs">
+  <ul>
     {{#if isBook}}
       <li id="contents-tab" class="tab contents-tab" data-content="contents" aria-controls="panel-contents" aria-selected="false" role="tab" tabindex="0">
         <span class="tab-title"><span class="fa fa-th-list"></span>Contents</span>
       </li>
     {{/if}}
-
-    <li id="tools-tab" class="tab tools-tab" data-content="tools" aria-controls="panel-tools" aria-selected="false" role="tab" tabindex="0">
-      <span class="tab-title"><span class="fa fa-cog"></span>Tools</span>
-    </li>
   </ul>
 
   <div id="panel-contents" class="contents tab-content" aria-labelledby="contents-tab" role="tabpanel">
     {{! Content View }}
   </div>
 
-  <div id="panel-tools" class="tools tab-content" aria-labelledby="tools-tab" role="tabpanel">
-    {{! Tools View }}
+  <div id="panel-metadata" class="metadata tab-content" aria-labelledby="metadata-tab" role="tabpanel">
+    {{! Metadata View }}
   </div>
 </div>

--- a/src/scripts/modules/media/tabs/tabs.coffee
+++ b/src/scripts/modules/media/tabs/tabs.coffee
@@ -3,7 +3,8 @@ define (require) ->
   linksHelper = require('cs!helpers/links')
   BaseView = require('cs!helpers/backbone/views/base')
   ContentsView = require('cs!./contents/contents')
-  ToolsView = require('cs!./tools/tools')
+  #ToolsView = require('cs!./tools/tools')
+  MetadataView = require('cs!./metadata/metadata')
   template = require('hbs!./tabs-template')
   require('less!./tabs')
 
@@ -14,7 +15,7 @@ define (require) ->
 
     regions:
       contents: '.contents'
-      tools: '.tools'
+      #tools: '.tools'
 
     events:
       'click .tab': 'selectTab'
@@ -26,7 +27,7 @@ define (require) ->
 
     onRender: () ->
       @regions.contents.show(new ContentsView({model: @model}))
-      @regions.tools.show(new ToolsView({model: @model}))
+      #@regions.tools.show(new ToolsView({model: @model}))
 
       components = linksHelper.getCurrentPathComponents()
 

--- a/src/scripts/router.coffee
+++ b/src/scripts/router.coffee
@@ -20,8 +20,8 @@ define (require) ->
       @route '', 'index', () ->
         @appView.render('home')
 
-      @route 'workspace', 'workspace', () ->
-        @appView.render('workspace')
+      #@route 'workspace', 'workspace', () ->
+      #  @appView.render('workspace')
 
       @route 'contents', 'contents', () ->
         @appView.render('contents')
@@ -35,8 +35,8 @@ define (require) ->
       @route 'license', 'license', () ->
         @appView.render('license')
 
-      @route /^users\/role-acceptance\/(.+)/, 'role-acceptance', () ->
-        @appView.render('role-acceptance')
+      #@route /^users\/role-acceptance\/(.+)/, 'role-acceptance', () ->
+      #  @appView.render('role-acceptance')
 
       # Match and extract uuid and page numbers separated by a colon
       @route linksHelper.contentsLinkRegEx, 'media', (uuid, version, page, title, qs) ->

--- a/src/scripts/settings.js
+++ b/src/scripts/settings.js
@@ -10,14 +10,14 @@
 
       // Hostname and port for the cnx-archive server
       cnxarchive: {
-        host: 'devarchive.cnx.org',
+        host: 'archive.cnx.org',
         port: 80
       },
 
       // Hostname and port for the cnx-authoring server
       cnxauthoring: {
-        host: location.hostname,
-        port: 8080
+        host: 'cnx.org',
+        port: 80
       },
 
       // Prefix to prepend to page titles


### PR DESCRIPTION
This should rollback the CC hash to what is currently deployed on production, to allow for rollout of other webview fixes, including google analytics codes, and scroll to target.