### PR TITLE
tracker name for GA must be alphanumeric

### DIFF
--- a/src/scripts/config.js
+++ b/src/scripts/config.js
@@ -205,6 +205,7 @@
 
     less: {
       logLevel: 1,
+      async: true,
 
       globalVars: {
         dependencyDir: '"/bower_components"'

--- a/src/scripts/helpers/handlers/analytics.coffee
+++ b/src/scripts/helpers/handlers/analytics.coffee
@@ -30,7 +30,9 @@ define (require) ->
       require ['analytics'], (ga) ->
         # Use the default analytics ID in settings if no account is specified
         account ?= settings.analyticsID
-        ga('create', account, 'auto', account)
+        # TODO investigate if we need a different name for our tracker name
+        trackerName = 'cnxTracker'
+        ga('create', account, 'auto', trackerName)
 
-        ga("#{account}.send", 'pageview', fragment)
+        ga("#{trackerName}.send", 'pageview', fragment)
         #@gaq(['_setAccount', account], ['_trackPageview', fragment])


### PR DESCRIPTION
# GA tracker doesn't like hyphens in the trackerName

Used [ga-debugger](https://developers.google.com/analytics/devguides/collection/analyticsjs/debugging) to trace problem

## Before
![screen shot 2016-02-04 at 3 12 52 pm](https://cloud.githubusercontent.com/assets/2483873/12829949/44d3ab32-cb52-11e5-96b9-d468b0b46a36.png)

## After
![screen shot 2016-02-04 at 3 13 33 pm](https://cloud.githubusercontent.com/assets/2483873/12829955/4e4b4968-cb52-11e5-8c55-22103f75e87f.png)

# also, get rid of lessc's warning about [XHR sync](https://github.com/Connexions/webview/pull/1375/files#diff-722f26ce6d75fb7d146f54a4ce91810cR208)

Only affects dev version, wasn't causing problems currently, but this error broke less rendering in sims repo for example in the latest Chrome

`require-less` tries to use XHR `async=false` option by default, this [no longer follows spec](https://xhr.spec.whatwg.org/#sync-warning)

![screen shot 2016-02-04 at 3 15 15 pm](https://cloud.githubusercontent.com/assets/2483873/12829931/2e17eeee-cb52-11e5-9cb9-dc8a4afd12d9.png)