### PR TITLE
allow unique trackers based on ga account id input to analytics.send

### DIFF
--- a/src/scripts/helpers/handlers/analytics.coffee
+++ b/src/scripts/helpers/handlers/analytics.coffee
@@ -13,26 +13,20 @@ define (require) ->
         q: [['create', settings.analyticsID, 'auto']],
         l: Date.now()
 
-      # ## Setup ga.js
-      #window._gaq ?= []
-
-      # Asynchronously load ga.js
-      #require(['https://www.google-analytics.com/ga.js'])
-
-    # Wrapper functions to add analytics events
-    #ga: () -> ga?.apply(@, arguments) # analytics.js
-    #gaq: () -> window._gaq?.push(arguments[0], arguments[1]) # ga.js
-
     # Send the current page to every analytics service
     send: (account, fragment = Backbone.history.fragment) ->
       if not /^\//.test(fragment) then fragment = '/' + fragment
 
-      require ['analytics'], (ga) ->
+      require ['analytics'], (ga) =>
         # Use the default analytics ID in settings if no account is specified
         account ?= settings.analyticsID
-        # TODO investigate if we need a different name for our tracker name
-        trackerName = 'cnxTracker'
+
+        # TODO investigate if we need specific names for our tracker name
+        trackerName = @getTrackerName(account)
         ga('create', account, 'auto', trackerName)
 
         ga("#{trackerName}.send", 'pageview', fragment)
-        #@gaq(['_setAccount', account], ['_trackPageview', fragment])
+
+    getTrackerName: (account) ->
+      # Strip non-alphanumeric characters for default trackerName
+      account.replace(/\W/g, '')


### PR DESCRIPTION
strips of non-alphanumeric characters from account string

Previous solution from #1375 meant all trackers would get confused since the same name would be submitted for various accounts.