### PR TITLE
Update CC with fixed build

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -23,7 +23,7 @@
     "require-handlebars-plugin": "1.0.0",
     "aloha-editor": "oerpub/Aloha-Editor#master",
     "select2": "3.5.4",
-    "concept-coach": "openstax/concept-coach#d-2016-02-105.a"
+    "concept-coach": "openstax/concept-coach#d-2016-02-05.b"
   },
   "devDependencies": {
     "chai": "3.2.0",


### PR DESCRIPTION
Earlier release had old code as result of a a missed `npm install` step.

Contains
 * Remember free response when switching between exercises
 * Screen to update student identifier