### PR TITLE
coach is being rolled back

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -23,7 +23,7 @@
     "require-handlebars-plugin": "1.0.0",
     "aloha-editor": "oerpub/Aloha-Editor#master",
     "select2": "3.5.4",
-    "concept-coach": "openstax/concept-coach#d-20160209.a.candidate"
+    "concept-coach": "openstax/concept-coach#d-20160210.b"
   },
   "devDependencies": {
     "chai": "3.2.0",


### PR DESCRIPTION
coach is being rolled back without student id update and free-response recall with openstax/react-components#42, and openstax/concept-coach#128 from ask-us fix #1381 

## About this coach release
The release notes for this [current version of concept-coach](https://github.com/openstax/concept-coach/releases/tag/d-20160210.b) are as follows:

This release is [d-20160128.a](https://github.com/openstax/concept-coach/releases/tag/d-20160128.a) -- the last official release -- with:
* :footprints:ture, :bug:fix allow passing through click event for filtering, for ask us button
  * openstax/concept-coach#128 
* :bug:fix add recovery to coreGroups
  * openstax/react-components#42, related to openstax/tutor-js#973

Original targeted release was [d-20160209.a.candidate](https://github.com/openstax/concept-coach/releases/tag/d-20160209.a.candidate).  The following were **retracted**:
* :bug:fix ~~Remember free response when switching between exercises~~
  * openstax/concept-coach#127
* :footprints:ture ~~Change student id~~
  * openstax/concept-coach#126