### PR TITLE
adds source maps

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -138,6 +138,7 @@ module.exports = (grunt) ->
           keepBuildDir: false
           preserveLicenseComments: false
           skipDirOptimize: true
+          generateSourceMaps: true
           optimize: 'none'
           stubModules: ['cs']
           modules: [{
@@ -210,6 +211,7 @@ module.exports = (grunt) ->
           'dist/scripts/**/*'
           'dist/styles/**/*.less'
           '!dist/scripts/main.js'
+          '!dist/scripts/main.js.map'
           '!dist/scripts/require.js'
           '!dist/scripts/settings.js'
           '!dist/scripts/aloha.js'
@@ -233,9 +235,13 @@ module.exports = (grunt) ->
     # Uglify
     uglify:
       dist:
+        options:
+          sourceMap: true
+          sourceMapIncludeSources: true
+          sourceMapIn: 'dist/scripts/main.js.map'
         files:
-          'dist/scripts/require.js': ['dist/scripts/require.js']
           'dist/scripts/main.js': ['dist/scripts/main.js']
+          'dist/scripts/require.js': ['dist/scripts/require.js']
 
     # HTML min
     htmlmin:


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/253202/13255882/433e6d5c-da16-11e5-9a0d-af8157364dc6.png)

The files load but I am not sure about the best places to set breakpoints to verify. Also, I did not look very hard to see if `requirejs` could include the original `.coffee` source (see screenshot)

Fixes #1378