### PR TITLE
update coach with free response fix

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -23,7 +23,7 @@
     "require-handlebars-plugin": "1.0.0",
     "aloha-editor": "oerpub/Aloha-Editor#master",
     "select2": "3.5.4",
-    "concept-coach": "openstax/concept-coach#d-20160216.a"
+    "concept-coach": "openstax/concept-coach#d-20160226.a"
   },
   "devDependencies": {
     "chai": "3.2.0",


### PR DESCRIPTION
Update with latest coach [release](https://github.com/openstax/concept-coach/releases/tag/d-20160226.a) that fixes the free response caching so that free response is remembered even when a different question has been answered.  see [these](https://www.pivotaltracker.com/story/show/113852189) [ticket](https://www.pivotaltracker.com/story/show/113851607) for details