### PR TITLE
prevent Cannot read property 'top' of undefined errors

### DIFF
--- a/src/scripts/modules/media/media.coffee
+++ b/src/scripts/modules/media/media.coffee
@@ -107,8 +107,8 @@ define (require) ->
         handleHeaderViewPinning()
         if isPinned
           obscured = $pinnable.height()
-          top = $(window.location.hash).position().top
-          $(window).scrollTop(top - obscured)
+          top = $(window.location.hash)?.position()?.top
+          $(window).scrollTop(top - obscured) if top
 
       Backbone.on('window:hashChange', _.debounce(adjustHashTop, 150))
 


### PR DESCRIPTION
from when hash changed query is not found.  This would happen whenever hash events fire and it's `#` or even when it's a valid hash change but the element is not found.

![screen shot 2016-02-26 at 3 48 25 pm](https://cloud.githubusercontent.com/assets/2483873/13366384/6b68d2fe-dca0-11e5-9e4e-7c770c7f79ef.png)
