### PR TITLE
Summary toggle shows only when abstract summary exists.

### DIFF
--- a/src/scripts/models/contents/node.coffee
+++ b/src/scripts/models/contents/node.coffee
@@ -38,7 +38,7 @@ define (require) ->
       #if @get('title') then delete response.title
       response.title = @get('title') or response.title
 
-      # extract abstract from cnxml wrapper
+      # extract abstract from wrapper
       if response.abstract?
         response.abstract = $(response.abstract).unwrap().html()
 

--- a/src/scripts/models/contents/node.coffee
+++ b/src/scripts/models/contents/node.coffee
@@ -38,6 +38,10 @@ define (require) ->
       #if @get('title') then delete response.title
       response.title = @get('title') or response.title
 
+      # extract abstract from cnxml wrapper
+      if response.abstract?
+        response.abstract = $(response.abstract).unwrap().html()
+
       if response.mediaType is 'application/vnd.org.cnx.collection'
         # Only load the contents once
         response.contents = @get('contents') or response.tree.contents or []


### PR DESCRIPTION
currentPage.abstract retained a cnxml wrapper which caused the header Summary toggle to display even when no abstract was present.