### PR TITLE
Fix/filter languages

### DIFF
--- a/src/scripts/collections/languages.coffee
+++ b/src/scripts/collections/languages.coffee
@@ -14,9 +14,10 @@ define (require) ->
       availableLanguages = {}
       codes = []
       _.each languages, (language) ->
+        code = language[0].substring(0, 2)
         lang =
-          code: language[0].substring(0, 2)
-          name: allLanguages["#{language[0].substring(0, 2)}"].english
+          code: code
+          name: allLanguages[code].english
         codes.push(lang)
 
       # Sort the languages in alphabetical order
@@ -24,7 +25,7 @@ define (require) ->
         return if a.name > b.name then 1 else -1
 
       for lang in codes
-        availableLanguages["#{lang.code}"] = allLanguages["#{lang.code}"]
+        availableLanguages[lang.code] = allLanguages[lang.code]
       return availableLanguages
 
     initialize: () ->

--- a/src/scripts/modules/media/body/content.less
+++ b/src/scripts/modules/media/body/content.less
@@ -306,7 +306,7 @@ figure[data-orient="vertical"] {
   .style(@display, enumerated) {
     // Since we have to "emulate" the list, reset and increment the `list-item` counter.
     counter-reset: list-item;
-    list-style-type: none;
+    list-style-type: decimal;
 
     > [data-type="item"],
     > li {
@@ -316,8 +316,8 @@ figure[data-orient="vertical"] {
     > [data-type="item"]::before,
     > li::before {
       content: attr(data-mark-prefix) counter(list-item, decimal) attr(data-mark-suffix) '. ';
-      margin-right: 0.2em;
-      margin-left: -1.2em;
+      margin-right: 1.1em;
+      margin-left: -0.5em;
     }
 
     // "Emulate" the numbering for inline numbered lists

--- a/src/scripts/modules/minimal/search/advanced/advanced.coffee
+++ b/src/scripts/modules/minimal/search/advanced/advanced.coffee
@@ -6,13 +6,14 @@ define (require) ->
   SearchHeaderView = require('cs!modules/search/header/header')
   BaseView = require('cs!helpers/backbone/views/base')
   template = require('hbs!modules/search/advanced/advanced-template')
+  availableLanguages = require('cs!collections/languages')
   require('less!./advanced')
 
   return class AdvancedSearchView extends BaseView
     template: template
     pageTitle: 'Advanced Search'
     templateHelpers:
-      languages: settings.languages
+      languages: availableLanguages.models[0].attributes
       years: [(new Date).getFullYear()..1999]
 
     regions:

--- a/src/scripts/modules/minimal/search/advanced/advanced.coffee
+++ b/src/scripts/modules/minimal/search/advanced/advanced.coffee
@@ -40,7 +40,6 @@ define (require) ->
       format = (obj) ->
         _.map obj, (limit, index) ->
           if not limit.value then return
-          limit.value = encodeURIComponent(limit.value)
 
           # Split keywords into multiple keyword:value pairs
           if limit.name is 'keywords'

--- a/src/scripts/modules/search/advanced/advanced.coffee
+++ b/src/scripts/modules/search/advanced/advanced.coffee
@@ -54,6 +54,7 @@ define (require) ->
 
     submitForm: (e) ->
       e.preventDefault()
+
       $form = $(e.currentTarget)
       values = $form.serializeArray()
       query = @formatQuery(values)
@@ -67,6 +68,7 @@ define (require) ->
       format = (obj) ->
         _.map obj, (limit, index) ->
           if not limit.value then return
+
           # Split keywords into multiple keyword:value pairs
           if limit.name is 'keywords'
             keywords = limit.value.match(/(?:[^\s"]+|"[^"]*")+/g)

--- a/src/scripts/modules/search/advanced/advanced.coffee
+++ b/src/scripts/modules/search/advanced/advanced.coffee
@@ -54,7 +54,6 @@ define (require) ->
 
     submitForm: (e) ->
       e.preventDefault()
-
       $form = $(e.currentTarget)
       values = $form.serializeArray()
       query = @formatQuery(values)
@@ -68,8 +67,6 @@ define (require) ->
       format = (obj) ->
         _.map obj, (limit, index) ->
           if not limit.value then return
-          limit.value = encodeURIComponent(limit.value)
-
           # Split keywords into multiple keyword:value pairs
           if limit.name is 'keywords'
             keywords = limit.value.match(/(?:[^\s"]+|"[^"]*")+/g)


### PR DESCRIPTION
Filters the languages on the advanced search options so that only the languages in which we have content is displayed. The languages are sorted in alphabetical order. 