### PR TITLE
Allow HTML to display correctly in titles

### DIFF
--- a/src/scripts/modules/media/tabs/contents/toc/page-template.html
+++ b/src/scripts/modules/media/tabs/contents/toc/page-template.html
@@ -4,7 +4,7 @@
       <a href="{{url}}" data-page="{{page}}" data-trigger="false">
         {{#if chapter}}<span class="chapter-number">{{chapter}}</span>{{/if}}
         <span class="title{{#if active}} active{{/if}}" data-depth="{{depth}}">
-          {{title}}
+          {{{title}}}
         </span>
         {{#if searchResult}}
           <div class="snippet">

--- a/src/scripts/modules/media/tabs/contents/toc/section-template.html
+++ b/src/scripts/modules/media/tabs/contents/toc/section-template.html
@@ -5,7 +5,7 @@
        {{#if expanded}}aria-expanded="true"{{else}}aria-expanded="false"{{/if}}>
        {{#if chapter}}<span class="chapter-number">{{chapter}}</span>{{/if}}
         <span class="title section">
-          {{title}}
+          {{{title}}}
         </span>
       </span>
 

--- a/src/scripts/modules/media/title/title-template.html
+++ b/src/scripts/modules/media/title/title-template.html
@@ -19,7 +19,7 @@
         {{#is status 'publishing'}}
           <span class="label label-info">publishing</span>
         {{/is}}
-        {{title}}
+        {{{title}}}
       </h1>
       {{#if parent.id}}
         <span>


### PR DESCRIPTION
HTML now displayed correctly
![screenshot from 2016-06-21 09-43-12](https://cloud.githubusercontent.com/assets/1394695/16233704/e31b1786-3794-11e6-8a38-575dccbfd839.png)

![screenshot from 2016-06-21 09-43-46](https://cloud.githubusercontent.com/assets/1394695/16233712/e8b0eb8a-3794-11e6-908b-f8a48821d434.png)
