### PR TITLE
fixes coach embed so it doesnt nest inside a hidden exercise section

### DIFF
--- a/src/scripts/modules/media/body/body.coffee
+++ b/src/scripts/modules/media/body/body.coffee
@@ -90,7 +90,7 @@ define (require) ->
 
     hideExercises: ($el) ->
       hiddenClasses = @getCoach()
-      hiddenSelectors = hiddenClasses.map((name) -> ".#{name}[data-depth=1]").join(', ')
+      hiddenSelectors = hiddenClasses.map((name) -> ".#{name}").join(', ')
       $exercisesToHide = $el.find(hiddenSelectors)
       $exercisesToHide.add($exercisesToHide.siblings('[data-type=title]')).hide()
 
@@ -99,7 +99,7 @@ define (require) ->
     makeRegionForCoach: ($exercises, wrapperId = 'coach-wrapper') ->
       $("##{wrapperId}").remove()
       $coachWrapper = $("<div id=\"#{wrapperId}\"></div>")
-      $coachWrapper.insertAfter(_.last($exercises))
+      $coachWrapper.insertBefore(_.first($exercises))
 
     handleCoach: ($el) ->
       return unless @isCoach()

--- a/src/scripts/modules/media/body/body.coffee
+++ b/src/scripts/modules/media/body/body.coffee
@@ -90,7 +90,7 @@ define (require) ->
 
     hideExercises: ($el) ->
       hiddenClasses = @getCoach()
-      hiddenSelectors = hiddenClasses.map((name) -> ".#{name}").join(', ')
+      hiddenSelectors = hiddenClasses.map((name) -> ".#{name}[data-depth=1]").join(', ')
       $exercisesToHide = $el.find(hiddenSelectors)
       $exercisesToHide.add($exercisesToHide.siblings('[data-type=title]')).hide()
 

--- a/src/scripts/settings.js
+++ b/src/scripts/settings.js
@@ -67,8 +67,8 @@
 
       conceptCoach: {
         uuids: {
-          'f10533ca-f803-490d-b935-88899941197f': ['exercise'],
-          '8QUzyvgD': ['exercise'] // only long-codes are currently supported
+          'f10533ca-f803-490d-b935-88899941197f': ['art-exercise', 'free-response', 'multiple-choice'],
+          '8QUzyvgD': ['art-exercise', 'free-response', 'multiple-choice'] // only long-codes are currently supported
         },
         url: 'https://tutor-qa.openstax.org'
       }


### PR DESCRIPTION
fixes [:bug: Launch Concept Coach is missing](https://www.pivotaltracker.com/story/show/123141311), looked the same since exercises get hidden, it doesnt matter if coach goes before or after.  this way, since dom get traversed from parents down to children, inserting before the first will ensure that coach never gets nested inside an exercise that was just hidden