### PR TITLE
fix: turns off numbering when the book is collated

### DIFF
--- a/src/scripts/models/contents/node.coffee
+++ b/src/scripts/models/contents/node.coffee
@@ -242,6 +242,11 @@ define (require) ->
 
       return pages
 
+    isCollated: () ->
+      book = if @isBook() then @ else @get('book')
+      collated = if book?.get('collated')? then book?.get('collated') else false
+      return collated
+
     isSection: () -> not @isBook() and @get('contents') instanceof Backbone.Collection
 
     isBook: () -> @get('mediaType') is 'application/vnd.org.cnx.collection'

--- a/src/scripts/modules/media/tabs/contents/contents.coffee
+++ b/src/scripts/modules/media/tabs/contents/contents.coffee
@@ -94,12 +94,14 @@ define (require) ->
       nodes = @model.get('contents')?.models
       if nodes?.length
         isCcap = nodes[0].isCcap()
-        if isCcap
-          sections = nodes.filter((node) -> node.isSection())
-          basicNumbering(sections)
-          continuousNumberChapters(sections)
-        else
-          basicNumbering(nodes)
+        isCollated = nodes[0].isCollated()
+        unless isCollated
+          if isCcap
+            sections = nodes.filter((node) -> node.isSection())
+            basicNumbering(sections)
+            continuousNumberChapters(sections)
+          else
+            basicNumbering(nodes)
         @allPages = allPages(nodes)
 
     expandContainers: (page, isExpanded, handlingResults) ->


### PR DESCRIPTION
Adds a check so that table of contents is not numbered when the book has been cooked. Also adds a method to node.coffee to check for the "collated" attribute.