### PR TITLE
Look for page in book using page id in href when rewriting href

### DIFF
--- a/src/scripts/modules/media/body/body.coffee
+++ b/src/scripts/modules/media/body/body.coffee
@@ -182,11 +182,13 @@ define (require) ->
               $el = $(el)
               href = $el.attr('href')
 
+              [href, fragment] = href.split('#')
               page = @model.getPage(href.substr(10))
+              fragment = fragment and "##{fragment}" or ''
 
               if page
                 pageNumber = page.getPageNumber()
-                $el.attr('href', "/contents/#{@model.getVersionedId()}:#{pageNumber}")
+                $el.attr('href', "/contents/#{@model.getVersionedId()}:#{pageNumber}#{fragment}")
                 $el.attr('data-page', pageNumber)
 
           # Add nofollow to external user-generated links


### PR DESCRIPTION
The code was for rewriting href like
"/contents/c8bdbabc-62b1-4a5f-b291-982ab25756d7" to
"/contents/031da8d3-b525-429c-80cf-6c8ed997733a@9.30:1" when the page id
is within the current book.

The code was not matching href like
"/contents/c8bdbabc-62b1-4a5f-b291-982ab25756d7#table" because it was
using everything after the "/contents/" as the page id when matching
against pages in the book.