### PR TITLE
Update CC; fixes bug with tasks using old state

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -23,7 +23,7 @@
     "require-handlebars-plugin": "1.0.0",
     "aloha-editor": "oerpub/Aloha-Editor#master",
     "select2": "3.5.4",
-    "concept-coach": "openstax/concept-coach#d-20160628.a"
+    "concept-coach": "openstax/concept-coach#d-20160708.a"
   },
   "devDependencies": {
     "chai": "3.2.0",


### PR DESCRIPTION
Fixes bug where after answering the free response in Concept Coach, something must be clicked to show the free response answer on the multiple choice step. Clicking on an answer selects the answer, but doesn't activate the submit button. Clicking on the breadcrumb, an answer, or window refresh will show the free response answer and clicking on a multiple choice answer at this point works.
