### PR TITLE
Use the authoring url if page is draft and archive url if book is draft

### DIFF
--- a/src/scripts/models/contents/node.coffee
+++ b/src/scripts/models/contents/node.coffee
@@ -28,6 +28,8 @@ define (require) ->
         url = "#{AUTHORING}/users/contents"
       else if @isDraft()
         url = "#{AUTHORING}/contents/#{id}.json" # FIX: Remove .json from URL
+      else if @get('book')?.isDraft()
+        url = "#{ARCHIVE}/contents/#{id}.json"
       else if @isInBook()
         book = @get('book')
         url = "#{ARCHIVE}/contents/#{book.getVersionedId()}:#{id}.json"


### PR DESCRIPTION
When a user derives a book, the page is not draft, so it tries to use
the archive contextual url which is 404 not found.