### PR TITLE
Use iso code instead of array index for languages in advanced search

### DIFF
--- a/src/scripts/modules/search/advanced/advanced-template.html
+++ b/src/scripts/modules/search/advanced/advanced-template.html
@@ -69,7 +69,7 @@
 	    <option value="">Any</option>
             {{~#if filtered~}}
               {{~#each languages~}}
-                <option value="{{@key}}">
+                <option value="{{this.attributes.id}}">
                   {{~#is this.attributes.native this.attributes.english~}}
                     {{this.attributes.native}}
                   {{~else~}}


### PR DESCRIPTION
On cnx.org, when we use advanced search to search for content in a
particular language, instead of doing /search?q=language:da, we're taken
to /search?q=language:6 and get no results.

When search languages are filtered, "languages" is an array and "@key" is
the array index.  This commit changes the code to use "id" instead,
which is the iso code.  (See src/scripts/collections/languages.coffee)