### PR TITLE
Fix/wrong page version in history

### DIFF
--- a/src/scripts/modules/media/footer/history/history.coffee
+++ b/src/scripts/modules/media/footer/history/history.coffee
@@ -7,19 +7,12 @@ define (require) ->
     template: template
     templateHelpers: () ->
         model = super()
-        #@media = $(e.currentTarget).data('media')
-        pageButton = @$el.find('[data-media="page"]').hasClass('active')
-        console.debug("pagebutton", pageButton)
-        console.debug("print this")
 
-        if pageButton # and @model.isBook
-          console.debug("here")
+        if @media is 'page'
           currentPage = @model.get('currentPage')
-          console.debug("current page", currentPage)
           model.uuid = currentPage.getUuid()
-          console.debug("model.uuid", model.uuid)
+
         else
-          console.debug("not page button")
           model.uuid = @model.getUuid()
 
         return model

--- a/src/scripts/modules/media/footer/history/history.coffee
+++ b/src/scripts/modules/media/footer/history/history.coffee
@@ -6,13 +6,13 @@ define (require) ->
   return class HistoryView extends FooterTabView
     template: template
     templateHelpers: () ->
-        model = super()
+      model = super()
 
-        if @media is 'page'
-          currentPage = @model.get('currentPage')
-          model.uuid = currentPage.getUuid()
+      if @media is 'page'
+        currentPage = @model.get('currentPage')
+        model.uuid = currentPage.getUuid()
 
-        else
-          model.uuid = @model.getUuid()
+      else
+        model.uuid = @model.getUuid()
 
-        return model
+      return model

--- a/src/scripts/modules/media/footer/history/history.coffee
+++ b/src/scripts/modules/media/footer/history/history.coffee
@@ -6,7 +6,20 @@ define (require) ->
   return class HistoryView extends FooterTabView
     template: template
     templateHelpers: () ->
-      model = super()
-      model.uuid = @model.getUuid()
+        model = super()
+        #@media = $(e.currentTarget).data('media')
+        pageButton = @$el.find('[data-media="page"]').hasClass('active')
+        console.debug("pagebutton", pageButton)
+        console.debug("print this")
 
-      return model
+        if pageButton # and @model.isBook
+          console.debug("here")
+          currentPage = @model.get('currentPage')
+          console.debug("current page", currentPage)
+          model.uuid = currentPage.getUuid()
+          console.debug("model.uuid", model.uuid)
+        else
+          console.debug("not page button")
+          model.uuid = @model.getUuid()
+
+        return model


### PR DESCRIPTION
Fixes the issue of page versions in the history tab pointing to a page that causes an error. Where it used to get the collection ID and attach the version, now it should get the page ID if in the "page" section of history tab and attach the version to go to the right page.