### PR TITLE
override list styles for coach so that they have single numbers

### DIFF
--- a/src/scripts/modules/media/body/body.less
+++ b/src/scripts/modules/media/body/body.less
@@ -95,6 +95,7 @@ body.cc-opened {
     visibility: hidden;
   }
 
+  // various overrides of webview styles for concept-coach
   .media-body > #content .concept-coach-wrapper {
     .dropdown-menu > li > a {
       text-decoration: none;
@@ -102,6 +103,18 @@ body.cc-opened {
 
     .concept-coach-title h3.chapter-section-prefix {
       margin-bottom: 0;
+    }
+
+    ol:not([data-display='inline']),
+    ol[data-display='inline'] {
+      > [data-type="item"]::before,
+      > li::before {
+        content: '';
+        display: none;
+      }
+
+      // or, set list style type to none
+      // list-style-type: none;
     }
 
   }


### PR DESCRIPTION
# Fixes [weird coach list formatting](https://www.pivotaltracker.com/story/show/126243975)

## from this:
![screen shot 2016-07-27 at 5 46 00 pm](https://cloud.githubusercontent.com/assets/2483873/17195186/0828153e-5422-11e6-8954-282f351c0ea8.png)

## to this:
![screen shot 2016-07-27 at 5 24 04 pm](https://cloud.githubusercontent.com/assets/2483873/17195098/88ab8e26-5421-11e6-8830-1038c722eaca.png)


# However

I don't think this is necessarily the right way to solve this problem/maybe I don't understand the full scope behind the list styles defined [here](https://github.com/Connexions/webview/blob/master/src/scripts/modules/media/body/content.less#L182-L365).

For example, if the purpose is to have custom control over the enumeration of `ol`s then why is this [`list-style-type`](https://github.com/Connexions/webview/blob/master/src/scripts/modules/media/body/content.less#L309) not set to `none` since the [`::before`](https://github.com/Connexions/webview/blob/master/src/scripts/modules/media/body/content.less#L316-L321) will be enumerating?

Or, instead, should these [selectors](https://github.com/Connexions/webview/blob/master/src/scripts/modules/media/body/content.less#L351-L352) be a little more strict and be something like `ol[data-display]:not([data-display='inline'])` such that only lists with `[data-display]` attribute be customized?

Either of these changes that affect webview more widely would make this PR unnecessary.