### PR TITLE
make selectors for list override more strict so that only lists with …

### DIFF
--- a/src/scripts/modules/media/body/content.less
+++ b/src/scripts/modules/media/body/content.less
@@ -348,8 +348,8 @@ figure[data-orient="vertical"] {
 
 
 // Block-ish lists
-ul:not([data-display='inline'])          { #list>.style(block; bulleted); }
-ol:not([data-display='inline'])          { #list>.style(block; enumerated); }
+ul[data-display]:not([data-display='inline'])          { #list>.style(block; bulleted); }
+ol[data-display]:not([data-display='inline'])          { #list>.style(block; enumerated); }
 ul[data-labeled-item]                    { #list>.style(block; labeled-item); }
 
 // Inline lists (with `data-display='inline'`)


### PR DESCRIPTION
# Fixes [weird coach list formatting](https://www.pivotaltracker.com/story/show/126243975)

## from this:
![screen shot 2016-07-27 at 5 46 00 pm](https://cloud.githubusercontent.com/assets/2483873/17195186/0828153e-5422-11e6-8954-282f351c0ea8.png)

## to this:
![screen shot 2016-07-27 at 5 24 04 pm](https://cloud.githubusercontent.com/assets/2483873/17195098/88ab8e26-5421-11e6-8830-1038c722eaca.png)

see #1438 for full details