### PR TITLE
Fix/donation slider

### DIFF
--- a/src/scripts/pages/donate/donation-slider/donation-slider.coffee
+++ b/src/scripts/pages/donate/donation-slider/donation-slider.coffee
@@ -80,14 +80,20 @@ define (require) ->
     onSlideStart: (e) ->
       slider = e.currentTarget
 
-      onSlide = (e) => @changeDonation.call(@, e)
-
+      onSlide = (e) =>
+        @changeDonation.call(@, e)
+        # fix for safari so that arrow keys work
+        $('[type="range"]').focus()
 
       onSlideStop = (e) ->
         # Remove event listeners when the user stops dragging the slider
         slider.removeEventListener('mousemove', onSlide, false)
         document.body.removeEventListener('mouseup', onSlideStop, false)
+        # fix for safari so that arrow keys work
+        $('[type="range"]').focus()
 
+      # fix for safari so that arrow keys work
+      $('[type="range"]').focus()
       slider.addEventListener('mousemove', onSlide, false)
       slider.addEventListener('input', onSlide, false)
       document.body.addEventListener('mouseup', onSlideStop, false)

--- a/src/scripts/pages/donate/donation-slider/donation-slider.coffee
+++ b/src/scripts/pages/donate/donation-slider/donation-slider.coffee
@@ -82,13 +82,14 @@ define (require) ->
 
       onSlide = (e) => @changeDonation.call(@, e)
 
+
       onSlideStop = (e) ->
         # Remove event listeners when the user stops dragging the slider
         slider.removeEventListener('mousemove', onSlide, false)
         document.body.removeEventListener('mouseup', onSlideStop, false)
 
-      # Add event listeners when the user starts dragging the slider
       slider.addEventListener('mousemove', onSlide, false)
+      slider.addEventListener('input', onSlide, false)
       document.body.addEventListener('mouseup', onSlideStop, false)
 
     changeDonation: (e) ->

--- a/src/scripts/pages/donate/donation-slider/donation-slider.coffee
+++ b/src/scripts/pages/donate/donation-slider/donation-slider.coffee
@@ -94,6 +94,7 @@ define (require) ->
 
       # fix for safari so that arrow keys work
       $('[type="range"]').focus()
+      # Add event listeners when the user starts dragging the slider
       slider.addEventListener('mousemove', onSlide, false)
       slider.addEventListener('input', onSlide, false)
       document.body.addEventListener('mouseup', onSlideStop, false)


### PR DESCRIPTION
Fixes the behavior of the donation slider in safari and firefox. In safari, the donation slider did not respond to arrow keys before. In firefox, the value for the donation was not changing with the arrow key before the fix. No fix was needed for chrome, and there is still an issue with viewing it in IE.
