### PR TITLE
update coach to latest release and make it mono repo compatible

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -23,7 +23,7 @@
     "require-handlebars-plugin": "1.0.0",
     "aloha-editor": "oerpub/Aloha-Editor#master",
     "select2": "3.5.4",
-    "concept-coach": "openstax/concept-coach#d-20160801.a"
+    "concept-coach": "openstax/tutor-js#coach-20160812.b"
   },
   "devDependencies": {
     "chai": "3.2.0",

--- a/src/scripts/config.js
+++ b/src/scripts/config.js
@@ -26,7 +26,7 @@
       // Use Minified Aloha because loading files in a different requirejs context is a royal pain
       aloha: '../../bower_components/aloha-editor/target/build-profile-with-oer/rjs-output/lib/aloha',
 
-      OpenStaxConceptCoach: '../../bower_components/concept-coach/dist/full-build.min',
+      OpenStaxConceptCoach: '../../bower_components/concept-coach/full-build.min',
 
       // ## UI Libraries and Helpers
       tooltip: 'helpers/backbone/views/attached/tooltip/tooltip',
@@ -160,7 +160,7 @@
 
       // concept-coach
       OpenStaxConceptCoach: {
-        deps: ['css!../../bower_components/concept-coach/assets/main'],
+        deps: ['css!../../bower_components/concept-coach/main.min'],
         exports: 'OpenStaxConceptCoach'
       }
     },


### PR DESCRIPTION
Update concept coach with [latest release](https://github.com/openstax/tutor-js/releases/tag/coach-20160812.b), changes for using coach from mono-repo