### PR TITLE
don't number footnote list w/ CSS

### DIFF
--- a/src/scripts/modules/media/body/content.less
+++ b/src/scripts/modules/media/body/content.less
@@ -51,9 +51,8 @@ pre {
 > [data-type="glossary"],
 > [data-type="footnote-refs"] {
   margin-top: 6rem;
-
-  > ol > li::before {
-    content: "" !important;
+  > ol {
+    list-style-type: none;
   }
 }
 


### PR DESCRIPTION
Make the CSS for suppressing footnote numbers work. (style: none)