### PR TITLE
fix missing coach on some sections, i.e. 4.3 in college physics

### DIFF
--- a/src/scripts/modules/media/body/body.coffee
+++ b/src/scripts/modules/media/body/body.coffee
@@ -104,7 +104,7 @@ define (require) ->
     handleCoach: ($el) ->
       return unless @isCoach()
       @hideExercises($el)
-      $summary = $el.find('section.summary[data-depth="1"], section.section-summary[data-depth="1"]')
+      $summary = $el.find('section.summary[data-depth], section.section-summary[data-depth]')
       @makeRegionForCoach($summary) if $summary.length > 0
 
     # Toggle the visibility of teacher's edition elements


### PR DESCRIPTION
As the update #1452 causing this is not yet on production -- you'll see coach [here on production](http://cnx.org/contents/JydfSfIS@3.7:ivpbwI-1@8/Newtons-Second-Law-of-Motion-C), but [not on qa](http://qa.cnx.org/contents/JydfSfIS@2.2:ivpbwI-1@8/Newtons-Second-Law-of-Motion-C)