### PR TITLE
remove all calls of session.update

### DIFF
--- a/src/scripts/modules/header/header.coffee
+++ b/src/scripts/modules/header/header.coffee
@@ -7,8 +7,6 @@ define (require) ->
   require('less!./header')
   require('bootstrapCollapse')
 
-  $(window).focus(session.update.bind(session))
-
   return class HeaderView extends BaseView
     template: template
     templateHelpers: () -> {
@@ -36,7 +34,6 @@ define (require) ->
       siteStatus: '.site-status'
 
     onRender: () ->
-      session.update()
       @regions.siteStatus.show(new SiteStatusView())
 
     skipTo: (e) ->

--- a/src/scripts/router.coffee
+++ b/src/scripts/router.coffee
@@ -58,7 +58,6 @@ define (require) ->
 
     navigate: (fragment, options = {}, cb) ->
       super(arguments...)
-      session.update() # Check for changes to the session status
       analytics.send() if options.analytics isnt false
       cb?()
       @trigger('navigate')


### PR DESCRIPTION
`session.update` is not needed on non-editor enabled webview.

### This is against the `production` branch

Do not put into `master`, for merging into `production`