### PR TITLE
updates coach to latest with safari warning, style updates for coach only

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -23,7 +23,7 @@
     "require-handlebars-plugin": "1.0.0",
     "aloha-editor": "oerpub/Aloha-Editor#master",
     "select2": "3.5.4",
-    "concept-coach": "openstax/tutor-js#coach-20160927.a"
+    "concept-coach": "openstax/tutor-js#coach-20161006.a"
   },
   "devDependencies": {
     "chai": "3.2.0",

--- a/src/scripts/modules/media/body/body.less
+++ b/src/scripts/modules/media/body/body.less
@@ -63,6 +63,8 @@ body {
 .concept-coach-wrapper {
   margin-top: 4rem;
 }
+
+// styles for coach scene, not opened.
 .media-body > #content {
   .concept-coach-wrapper {
     h1 {
@@ -85,6 +87,7 @@ body {
   }
 }
 
+// styles for coach opened.
 body.cc-opened {
   .concept-coach-wrapper {
     text-align: left;
@@ -96,9 +99,14 @@ body.cc-opened {
   }
 
   .media-body > #content .concept-coach-wrapper {
-    p, h1 {
+    p, h1, h2, h3, h4, h5, h6 {
       color: inherit;
-      margin-bottom: inherit;
+    }
+
+    .concept-coach-view {
+      p, h1, h2, h3, h4, h5, h6 {
+        margin-bottom: inherit;
+      }
     }
 
     .dropdown-menu > li > a {


### PR DESCRIPTION
Updates coach to [latest release](https://github.com/openstax/tutor-js/releases/tag/coach-20161006.a) with Safari warning, also fixes closing on no exercises error