### PR TITLE
use an accessible version of the summary toggle

### DIFF
--- a/src/scripts/modules/media/header/header-template.html
+++ b/src/scripts/modules/media/header/header-template.html
@@ -62,10 +62,10 @@
     </div>
 
     {{#if currentPage.abstract}}
-      <div class="summary">
-        <a class="toggle" href="#"><h5>Summary</h5></a>
+      <details>
+        <summary>Summary</summary>
         <div class="abstract">{{include currentPage.abstract}}</div>
-      </div>
+      </details>
     {{/if}}
   </div>
 {{/if}}

--- a/src/scripts/modules/media/header/header.coffee
+++ b/src/scripts/modules/media/header/header.coffee
@@ -71,7 +71,6 @@ define (require) ->
       button: '.info .btn'
 
     events:
-      'click .summary .toggle': 'toggleSummary'
       'click .derive .btn': 'derivePage'
       'click .edit .btn' : 'editPage'
       'click .jump-to-cc > .btn': 'jumpToConceptCoach'
@@ -108,12 +107,6 @@ define (require) ->
 
     isCoach: ->
       @getCoach()?
-
-    toggleSummary: (e) ->
-      e.preventDefault()
-      $summary = @$el.find('.summary')
-      $summary.find('h5').toggleClass('active')
-      @$el.find('.abstract').toggle()
 
     editPage: () ->
       data = JSON.stringify({id: @model.asPage().get('id')})

--- a/src/scripts/modules/media/header/header.less
+++ b/src/scripts/modules/media/header/header.less
@@ -83,25 +83,15 @@
     }
   }
 
-  > .summary {
+  > details {
     margin-top: 1.5rem;
 
-    h5 {
+    summary {
       .user-select(none);
       cursor: pointer;
-
-      &::before {
-        margin-right: .5rem;
-        content: "\25b8"; // ▸
-      }
-
-      &.active::before {
-        content: "\25be"; // ▾
-      }
     }
 
     > .abstract {
-      display: none; // Hide until the summary is toggled open
 
       @media (min-width: @screen-sm-min) {
         max-width: 67%;


### PR DESCRIPTION
This also removes the need for a toggle JS and an anchor
# Screenshots

expanded:
![image](https://cloud.githubusercontent.com/assets/253202/19533312/343ab00a-960d-11e6-82a0-4347fc1c7845.png)

<details>
<summary>

nothing selected</summary>


![image](https://cloud.githubusercontent.com/assets/253202/19533283/146b6b66-960d-11e6-9ce6-ad2de4a302bf.png)
</details>

<details>
<summary>

collapsed again</summary>


![image](https://cloud.githubusercontent.com/assets/253202/19533328/464a0912-960d-11e6-9015-5866c49c4d6c.png)
</details>
# Old Screenshot

<details>
<summary>

Old Code expanded</summary>


![image](https://cloud.githubusercontent.com/assets/253202/19533358/6de57254-960d-11e6-99bf-1c183acc49a0.png)

</details>
