### PR TITLE
coffeescript compatibility

### DIFF
--- a/src/scripts/config.js
+++ b/src/scripts/config.js
@@ -50,7 +50,7 @@
 
       // # CoffeeScript
       cs: '../../bower_components/require-cs/cs',
-      'coffee-script': '../../bower_components/coffeescript/extras/coffee-script'
+      'coffee-script': '../../bower_components/coffeescript/docs/v1/browser-compiler/coffee-script'
     },
 
     // # Packages


### PR DESCRIPTION
if you ever clean out your `bower_components` folder<sup>[*](#myfoot)</sup> and re-install, a newer not-exactly-compatible version of `coffeescript` gets installed from the `require-cs` [dependencies](https://github.com/requirejs/require-cs/blob/842e8b8568536bcf7efcbea756560c6d7373e5ff/bower.json#L7).  they've [moved their browser-side compiler](https://github.com/jashkenas/coffeescript/compare/1.11.1...1.12.0#diff-45f508b714a4ac328c10a4c5a0e09dcaL304) between versions `1.11.1` and `1.12.0` from the `extras` subdir to `docs/v#{majorVersion}/browser-compiler/`.

I suspect this might happen even without purging `bower_components`...anyways, `coffeescript@1.12.0` was released 16 days ago so that might be why we haven't run into this issue yet


<a name="myfoot">*</a>which, really we should seeing as how `.nvmrc` is now being used, meaning `npm` will be updated, and so all dependencies should be cleanly re-installed as well

