### PR TITLE
Update coach against production

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -23,7 +23,7 @@
     "require-handlebars-plugin": "1.0.0",
     "aloha-editor": "oerpub/Aloha-Editor#master",
     "select2": "3.5.4",
-    "concept-coach": "openstax/tutor-js#coach-20161101.a"
+    "concept-coach": "openstax/tutor-js#coach-20161221.a"
   },
   "devDependencies": {
     "chai": "3.2.0",

--- a/src/scripts/config.js
+++ b/src/scripts/config.js
@@ -50,7 +50,7 @@
 
       // # CoffeeScript
       cs: '../../bower_components/require-cs/cs',
-      'coffee-script': '../../bower_components/coffeescript/extras/coffee-script'
+      'coffee-script': '../../bower_components/coffeescript/docs/v1/browser-compiler/coffee-script'
     },
 
     // # Packages


### PR DESCRIPTION
pulls in latest [coach updates](https://github.com/openstax/tutor-js/releases/tag/coach-20161221.a) and coffeescript fix in #1476