### PR TITLE
Update CC; bugfixes and wording updates

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -23,7 +23,7 @@
     "require-handlebars-plugin": "1.0.0",
     "aloha-editor": "oerpub/Aloha-Editor#master",
     "select2": "3.5.4",
-    "concept-coach": "openstax/tutor-js#coach-20170104.b"
+    "concept-coach": "openstax/tutor-js#coach-20170104.c"
   },
   "devDependencies": {
     "chai": "3.2.0",


### PR DESCRIPTION
Updates various labels to say "link" vs "code" for enrollment

Fixes bugs with

 * Second semester banner link
 * continue button not enabled
 * Summary missing from breadcrumb
 * Duplicated notification