### PR TITLE
Bump CC to version with updated re-enroll message

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -23,7 +23,7 @@
     "require-handlebars-plugin": "1.0.0",
     "aloha-editor": "oerpub/Aloha-Editor#master",
     "select2": "3.5.4",
-    "concept-coach": "openstax/tutor-js#coach-20170104.c"
+    "concept-coach": "openstax/tutor-js#coach-20170110.a"
   },
   "devDependencies": {
     "chai": "3.2.0",


### PR DESCRIPTION
Updates the course has ended bar's second-semester action

![screen shot 2017-01-10 at 3 32 41 pm](https://cloud.githubusercontent.com/assets/79566/21826550/911eb92a-d74d-11e6-813f-99a5d2eb01ae.png)
