### PR TITLE
Display display Jump to CC button, regardless of screen size

### DIFF
--- a/src/scripts/modules/media/header/header.less
+++ b/src/scripts/modules/media/header/header.less
@@ -69,13 +69,15 @@
 
     > .downloads,
     > .jump-to-cc {
-      @media (max-width: @screen-xs-max) {
-        display: none;
-      }
-
       > .btn {
         margin: 0 0 2rem auto;
       }
+      @media (max-width: @screen-xs-max) {
+        > .btn {
+          margin: 2rem auto;
+        }
+      }
+
     }
 
     > .jump-to-cc > .btn {


### PR DESCRIPTION
Previously the button was hidden on smallest screen size, this displays it with some margins

![screen shot 2017-02-20 at 10 43 34 am](https://cloud.githubusercontent.com/assets/79566/23134248/ae460400-f759-11e6-9014-37b47beb9288.png)
