### PR TITLE
Check subcol references

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,8 @@
   "version": "0.21.11-dev",
   "description": "Connexions (cnx.org) web site",
   "scripts": {
+    "start": "grunt nginx:start",
+    "stop": "grunt nginx:stop",
     "prepublish": "bower install --config.analytics=false; grunt aloha --verbose",
     "update": "npm update; bower update --config.analytics=false; grunt aloha --verbose",
     "test": "grunt test --verbose",

--- a/script/start
+++ b/script/start
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-$(npm bin)/grunt nginx:start
+npm start

--- a/script/stop
+++ b/script/stop
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-$(npm bin)/grunt nginx:stop
+npm run-script stop

--- a/src/scripts/helpers/handlers/analytics.coffee
+++ b/src/scripts/helpers/handlers/analytics.coffee
@@ -23,9 +23,9 @@ define (require) ->
 
         # TODO investigate if we need specific names for our tracker name
         trackerName = @getTrackerName(account)
-        ga('create', account, 'auto', trackerName)
+        ga?('create', account, 'auto', trackerName)
 
-        ga("#{trackerName}.send", 'pageview', fragment)
+        ga?("#{trackerName}.send", 'pageview', fragment)
 
     getTrackerName: (account) ->
       # Strip non-alphanumeric characters for default trackerName

--- a/src/scripts/models/content.coffee
+++ b/src/scripts/models/content.coffee
@@ -80,10 +80,13 @@ define (require) ->
         @set('childChanged', false)
 
     toJSON: (options = {}) ->
+      # This method is used for editing drafts as well as the JSON being sent to the handlebars template.
+      # Deleting the subcollection id may be problematic when attempting to use it in the
+      # Handlebars template but it does not seem to cause problems now.
       results = super(arguments...)
 
       # Prevent new books with no id from being labelled a subcollection
-      if results.id is 'subcol'
+      if results.id is 'subcol' or results.collated
         delete results.id
 
       if options.includeTree and @isBook()

--- a/src/scripts/settings.js
+++ b/src/scripts/settings.js
@@ -10,7 +10,7 @@
 
       // Hostname and port for the cnx-archive server
       cnxarchive: {
-        host: 'archive-cte-cnx-dev.cnx.org',
+        host: 'archive-dev00.cnx.org',
         port: 80
       },
 


### PR DESCRIPTION
It seems the references to `id == 'subcol'` in the code are for editing-mode and are basically no-ops when just viewing content. But I added a check just-in-case 😄 

/cc @pandafulmanda since she was working on editing mode