### PR TITLE
Fix for the IE 11

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -201,6 +201,9 @@ module.exports = (grunt) ->
       Template:
         src: 'bower_components/l20n/dist/compat/web/Template.js'
         dest: 'dist/scripts/Template.js'
+      polyfill:
+        src: 'bower_components/babel-polyfill/browser-polyfill.js'
+        dest: 'dist/scripts/browser.js'
       fonts:
         expand: true
         filter: 'isFile'
@@ -218,6 +221,7 @@ module.exports = (grunt) ->
           'dist/styles/**/*.less'
           '!dist/scripts/l20n.js'
           '!dist/scripts/Template.js'
+          '!dist/scripts/browser.js'
           '!dist/scripts/main.js'
           '!dist/scripts/main.js.map'
           '!dist/scripts/require.js'

--- a/src/index.html
+++ b/src/index.html
@@ -26,8 +26,9 @@
     <!--(if target dist)>
       <script data-main="/scripts/main" src="/scripts/require.js" async></script>
     <!(endif)-->
+    <script src="scripts/browser.js"></script>
+    <script src="scripts/Template.js"></script>
     <script defer src="scripts/l20n.js"></script>
-    <script defer src="scripts/Template.js"></script>
   </head>
   <body>
     <script>

--- a/src/locale/en-US/dictionary.ftl
+++ b/src/locale/en-US/dictionary.ftl
@@ -793,7 +793,7 @@ textbook-view-page-button = Page
 textbook-view-license = This work is licensed { LEN($licensors) ->
     [0]
    *[other] by { $licensors }
-  }{ LEN($name) ->
+  } { LEN($name) ->
     [0]
    *[other] under a <a href="{ $url }">{ $name } ({ $code } { $version })</a>
   }.

--- a/src/locale/pl/dictionary.ftl
+++ b/src/locale/pl/dictionary.ftl
@@ -833,7 +833,7 @@ textbook-view-page-button = Strona
 textbook-view-license = Zasób udostępniony { LEN($licensors) ->
     [0]
    *[other] przez { $licensors }
-  }{ LEN($name) ->
+  } { LEN($name) ->
     [0]
    *[other] na licencji <a href="{ $url }">{ $name } ({ $code } { $version })</a>
   }.


### PR DESCRIPTION
### Webview
This pull request resolves bugs:
1. Website staging.cnx.org is not loading in IE 11.
2. Missing space at the bottom of the content where the license is displayed. You have to go to the 2nd page of a book to see it.

### l20n
We also sent a PR to the our version of l20n on the https://github.com/katalysteducation/l20n.js so you have to do `bower update` to get new version of l20n which contains fixes to use hyperlinks in the FTL code. This pull request resolves bugs:
1. License display should be a link to Creative Commons. The href is missing in the <a> tag