### PR TITLE
CustomEvent polyfill is needed for IE 11 as well

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -25,7 +25,8 @@
     "select2": "3.5.4",
     "babel-polyfill": "^0.0.1",
     "l20n": "https://github.com/katalysteducation/l20n.js.git",
-    "concept-coach": "openstax/tutor-js#coach-20170308.c"
+    "concept-coach": "openstax/tutor-js#coach-20170308.c",
+    "custom-event-polyfill": "^0.3.0"
   },
   "devDependencies": {
     "chai": "3.2.0",

--- a/src/scripts/config.js
+++ b/src/scripts/config.js
@@ -59,7 +59,8 @@
       // l20n
       l20n: '../../bower_components/l20n/dist/compat/web/l20n',
       templatePolyfill: '../../bower_components/l20n/dist/compat/web/Template',
-      babelPolyfill: '../../bower_components/babel-polyfill/browser-polyfill'
+      babelPolyfill: '../../bower_components/babel-polyfill/browser-polyfill',
+      customEventPolyfill: '../../bower_components/custom-event-polyfill/custom-event-polyfill'
     },
 
     // # Packages
@@ -175,7 +176,7 @@
 
       l20n: {
         exports: 'L20n',
-        deps: ['templatePolyfill', 'babelPolyfill'],
+        deps: ['templatePolyfill', 'babelPolyfill', 'customEventPolyfill'],
         init: function () {
           // work-around until https://github.com/katalysteducation/l20n.js/pull/1 is merged.
           document.l10n.connectRoot(document.documentElement);


### PR DESCRIPTION
[CustomEvent](https://github.com/katalysteducation/l20n.js/blob/master/src/bindings/dom_localization.js#L186) was throwing off [IE 11's game](http://stackoverflow.com/questions/26596123/internet-explorer-9-10-11-event-constructor-doesnt-work).