### PR TITLE
verify that the l10n keys exist in the dictionary

### DIFF
--- a/script/check-templates-for-non-i18n-text.js
+++ b/script/check-templates-for-non-i18n-text.js
@@ -3,7 +3,12 @@ const glob = require('glob')
 const jsdom = require('jsdom')
 const jquery = require('jquery')
 
+
 glob('./src/**/*.html', (err, filenames) => {
+
+  // fill up all the keys and then check that they are defined in the locale files
+  const allKeysMap = {}
+
   filenames.forEach((filename) => {
 
     // Skip certain files
@@ -14,6 +19,12 @@ glob('./src/**/*.html', (err, filenames) => {
     const contents = fs.readFileSync(filename)
     const document = jsdom.jsdom(`<html><body>${contents}</body></html>`)
     const $ = jquery(document.defaultView)
+
+    // Find all the data-l10n-id attributes and look up to see if entries exist in all the languages
+    $('[data-l10n-id]').each((index, el) => {
+      const key = el.getAttribute('data-l10n-id')
+      allKeysMap[key] = true
+    })
 
     // Remove any text inside elements that are marked with a data-l10n-id
     // TODO: Verify all data-l10n-id values are in the JSON (warn if not in the polish ones)
@@ -48,5 +59,28 @@ glob('./src/**/*.html', (err, filenames) => {
       console.log('----------------------------------------------------');
       process.exit(1)
     }
+  })
+
+  // Check that all the keys are defined in the language files
+  glob('./src/locale/*/dictionary.ftl', (err, languageFiles) => {
+
+    languageFiles.forEach((languageFile) => {
+      const languageContent = fs.readFileSync(languageFile)
+      const allKeys = Object.keys(allKeysMap)
+      for (const i in allKeys) {
+        const key = allKeys[i]
+
+        if (languageContent.indexOf(`${key} =`) < 0) {
+
+          if (key.indexOf('{') < 0) {
+            console.error(`BUG: Missing key '${key}' in ${languageFile}`)
+            process.exit(1)
+          } else {
+            console.warn(`WARN: Skipping key because it is dynamically constructed: '${key}'`)
+          }
+        }
+      }
+
+    })
   })
 })

--- a/script/check-templates-for-non-i18n-text.js
+++ b/script/check-templates-for-non-i18n-text.js
@@ -73,7 +73,7 @@ glob('./src/**/*.html', (err, filenames) => {
         if (languageContent.indexOf(`${key} =`) < 0) {
 
           if (key.indexOf('{') < 0) {
-            console.error(`BUG: Missing key '${key}' in ${languageFile}`)
+            console.error(`BUG: Missing key in ${languageFile}: '${key}'`)
             process.exit(1)
           } else {
             console.warn(`WARN: Skipping key because it is dynamically constructed: '${key}'`)

--- a/src/locale/pl/dictionary.ftl
+++ b/src/locale/pl/dictionary.ftl
@@ -856,12 +856,16 @@ workspace-delete-OK = OK
 
 # MY WORKSPACE - Popover - src/scripts/modules/workspace/popovers/new/modals/new-media-template.html
 
+workspace-popover-create-new = Utwórz Nową
+
 workspace-popover-title-label = Tytuł
 
 workspace-popover-title-input =
   [html/placeholder]  Tytuł
 
 workspace-popover-cancel-button = Anuluj
+
+workspace-popover-create-new-button = Utwórz Nową
 
 # MY WORKSPACE - Page Title, Summary, Description - src/scripts/pages/workspace/workspace.coffee
 
@@ -901,6 +905,49 @@ workspace-results-plural = { $items ->
 # Content related to editor that enables the creation and editing of textbooks.
 
 # TEXTBOOK EDITOR - Editbar Styling - src/scripts/modules/media/editbar/editbar-template.html
+
+textbook-editor-toggle-navigation = Przełącz nawigację
+
+textbook-editor-edit = Edytuj
+
+textbook-editor-normal-text-button = Normalny Tekst
+
+textbook-editor-normal-text = Normalny Tekst
+
+textbook-editor-h1 = Nagłówek 1
+textbook-editor-h2 = Nagłówek 2
+textbook-editor-h3 = Nagłówek 3
+
+textbook-editor-code = Kod
+
+textbook-editor-bold =
+  [html/title] Pogrubiony
+textbook-editor-italic =
+  [html/title] Kursywa
+textbook-editor-underline =
+  [html/title] Podkreślać
+textbook-editor-superscript =
+  [html/title] Napisany u góry
+textbook-editor-subscript =
+  [html/title] Indeks
+
+textbook-editor-add-row-before = Dodaj wiersz przed
+textbook-editor-add-row-after = Dodaj wiersz po
+textbook-editor-add-column-before = Dodaj kolumnę przed
+textbook-editor-add-column-after = Dodaj kolumnę po
+textbook-editor-add-header-row = Dodaj wiersz nagłówka
+textbook-editor-delete-row = Usuń wiersz
+textbook-editor-delete-column = Usuń kolumnę
+textbook-editor-delete-table = Usuń tabelę
+
+textbook-editor-paste-button =
+  [html/data-content] Treść została skopiowana do schowka. Kliknij ten przycisk, aby wkleić treść do strony.
+
+textbook-editor-save-draft = Zapisz Projekt
+
+textbook-editor-publish-button = Publikacja...
+
+textbook-editor-drag-to-add = Przeciągnij, aby dodać nową...
 
 # TEXTBOOK EDITOR - Tabs Add Page - src/scripts/modules/media/tabs/contents/popovers/add/modals/add-page-template.html
 


### PR DESCRIPTION
This is a followup to issues raised in #1521


It checks that the l10n keys which are found in the HTML templates actually exist in the `dictionary.ftl` files.

And unsurprisingly, it finds some missing ones 😄  (see Travis output):

```
BUG: Missing key in ./src/locale/pl/dictionary.ftl: 'textbook-editor-toggle-navigation'
```

<details>
<summary>Click me for the full list</summary>

I just commented out the `process.exit(1)` line in the `.js` file

```
BUG: Missing key in ./src/locale/pl/dictionary.ftl: 'textbook-editor-toggle-navigation'
BUG: Missing key in ./src/locale/pl/dictionary.ftl: 'textbook-editor-edit'
BUG: Missing key in ./src/locale/pl/dictionary.ftl: 'textbook-editor-normal-text-button'
BUG: Missing key in ./src/locale/pl/dictionary.ftl: 'textbook-editor-normal-text'
BUG: Missing key in ./src/locale/pl/dictionary.ftl: 'textbook-editor-h1'
BUG: Missing key in ./src/locale/pl/dictionary.ftl: 'textbook-editor-h2'
BUG: Missing key in ./src/locale/pl/dictionary.ftl: 'textbook-editor-h3'
BUG: Missing key in ./src/locale/pl/dictionary.ftl: 'textbook-editor-code'
BUG: Missing key in ./src/locale/pl/dictionary.ftl: 'textbook-editor-bold'
BUG: Missing key in ./src/locale/pl/dictionary.ftl: 'textbook-editor-italic'
BUG: Missing key in ./src/locale/pl/dictionary.ftl: 'textbook-editor-underline'
BUG: Missing key in ./src/locale/pl/dictionary.ftl: 'textbook-editor-superscript'
BUG: Missing key in ./src/locale/pl/dictionary.ftl: 'textbook-editor-subscript'
BUG: Missing key in ./src/locale/pl/dictionary.ftl: 'textbook-editor-add-row-before'
BUG: Missing key in ./src/locale/pl/dictionary.ftl: 'textbook-editor-add-row-after'
BUG: Missing key in ./src/locale/pl/dictionary.ftl: 'textbook-editor-add-column-before'
BUG: Missing key in ./src/locale/pl/dictionary.ftl: 'textbook-editor-add-column-after'
BUG: Missing key in ./src/locale/pl/dictionary.ftl: 'textbook-editor-add-header-row'
BUG: Missing key in ./src/locale/pl/dictionary.ftl: 'textbook-editor-delete-row'
BUG: Missing key in ./src/locale/pl/dictionary.ftl: 'textbook-editor-delete-column'
BUG: Missing key in ./src/locale/pl/dictionary.ftl: 'textbook-editor-delete-table'
BUG: Missing key in ./src/locale/pl/dictionary.ftl: 'textbook-editor-paste-button'
BUG: Missing key in ./src/locale/pl/dictionary.ftl: 'textbook-editor-save-draft'
BUG: Missing key in ./src/locale/pl/dictionary.ftl: 'textbook-editor-publish-button'
BUG: Missing key in ./src/locale/pl/dictionary.ftl: 'textbook-editor-drag-to-add'
BUG: Missing key in ./src/locale/pl/dictionary.ftl: 'workspace-popover-create-new'
BUG: Missing key in ./src/locale/pl/dictionary.ftl: 'workspace-popover-create-new-button'
```

</details>