### PR TITLE
update mathjax and move the CDN domain

### DIFF
--- a/src/scripts/config.js
+++ b/src/scripts/config.js
@@ -25,7 +25,7 @@
       'backbone-associations': '../../bower_components/backbone-associations/backbone-associations',
 
       // ## MathJax
-      mathjax: '//cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=MML_HTMLorMML',
+      mathjax: '//cdnjs.cloudflare.com/ajax/libs/mathjax/2.6.1/MathJax.js?config=MML_HTMLorMML',
 
       // Use Minified Aloha because loading files in a different requirejs context is a royal pain
       aloha: '../../bower_components/aloha-editor/target/build-profile-with-oer/rjs-output/lib/aloha',

--- a/src/scripts/config.js
+++ b/src/scripts/config.js
@@ -25,7 +25,7 @@
       'backbone-associations': '../../bower_components/backbone-associations/backbone-associations',
 
       // ## MathJax
-      mathjax: '//cdn.mathjax.org/mathjax/2.6-latest/MathJax.js?config=MML_HTMLorMML',
+      mathjax: '//cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=MML_HTMLorMML',
 
       // Use Minified Aloha because loading files in a different requirejs context is a royal pain
       aloha: '../../bower_components/aloha-editor/target/build-profile-with-oer/rjs-output/lib/aloha',


### PR DESCRIPTION
From https://www.mathjax.org/cdn-shutting-down/ . This updates MathJax to 2.7.0 (from `2.6-latest`) and changes the domain to be cloudflare .

An alternative would be to build mathjax locally and host it as part of webview but that would increase the JS file size significantly. 

Chunking could bring the size back down a bit but would require a bit more dev work to only load MathJax when needed. And make sure the font files are hosted properly (correct path and content type headers)