### PR TITLE
Increase the timeout for requirejs modules

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -133,6 +133,7 @@ module.exports = (grunt) ->
           baseUrl: 'scripts'
           dir: 'dist'
           mainConfigFile: 'src/scripts/config.js'
+          waitSeconds: 360 # Jenkins takes a while to build (when running multiple jobs)
           findNestedDependencies: true
           removeCombined: false
           keepBuildDir: false


### PR DESCRIPTION
It seems `requirejs` occasionally times out when building the `main.min.js`. One case where this happens is when Jenkins is running more than one job at a time.

This should _hopefully_ fix the problem.