### PR TITLE
WIP Don't pass title into ftl template, might contain markup

### DIFF
--- a/src/locale/en-US/dictionary.ftl
+++ b/src/locale/en-US/dictionary.ftl
@@ -595,7 +595,9 @@ textbook-view-btn-create = Create an Editable Copy
 
 textbook-view-publishing = publishing { $title }
 
-textbook-view-derived-from = Derived from <a href="{ $url }">{ $title }</a> by <span class="collection-authors">{ TAKE(50, $authors) }</span>
+textbook-view-derived-from = Derived from
+
+textbook-view-derived-from-by = by
 
 textbook-view-book-by =
   | Book by: <span class="collection-authors">{ TAKE(50, $authors) }</span>
@@ -687,17 +689,11 @@ textbook-view-btn-get-this-page = Get This Page!
 
 textbook-view-summary = Summary
 
-textbook-view-header-publishing = <span class="label label-info">publishing</span> { $title }
+textbook-view-header-publishing = publishing
 
-textbook-view-header-publishing-chapter =
-  | <span class="label label-info">publishing</span> <span class="title-chapter">{ $chapter }</span> { $title }
+textbook-view-header-derived-from = Derived from
 
-textbook-view-header-no-publishing = { $title }
-
-textbook-view-header-no-publishing-chapter = <span class="title-chapter">{ $chapter }</span> { $title }
-
-textbook-view-header-derived-from =
-  | Derived from <a href="{ $url }">{ $title }</a> by <span class="book-authors">{ TAKE(50, $authors) }</span>
+textbook-view-header-derived-from-by = by
 
 # TEXTBOOK VIEW - Metadata - src/scripts/modules/media/footer/metadata/metadata-template.html
 

--- a/src/locale/pl/dictionary.ftl
+++ b/src/locale/pl/dictionary.ftl
@@ -596,9 +596,11 @@ textbook-view-btn-edit = Edytuj
 
 textbook-view-btn-create = Utwórz kopię do edycji
 
-textbook-view-publishing = publikujesz { $title }
+textbook-view-publishing = publikujesz
 
-textbook-view-derived-from = Utworzone z <a href="{ $url }">{ $title }</a> przez <span class="collection-authors">{ TAKE(50, $authors) }</span>
+textbook-view-derived-from = Utworzone z
+
+textbook-view-derived-from-by = przez
 
 textbook-view-book-by =
   | Utworzone przez: <span class="collection-authors">{ TAKE(50, $authors) }</span>
@@ -692,17 +694,11 @@ textbook-view-btn-get-this-page = Weź tę stronę!
 
 textbook-view-summary = Podsumowanie
 
-textbook-view-header-publishing = <span class="label label-info">publikujesz</span> { $title }
+textbook-view-header-publishing = publikujesz
 
-textbook-view-header-publishing-chapter =
-  | <span class="label label-info">publikujesz</span> <span class="title-chapter">{ $chapter }</span> { $title }
+textbook-view-header-derived-from = Utworzone z
 
-textbook-view-header-no-publishing = { $title }
-
-textbook-view-header-no-publishing-chapter = <span class="title-chapter">{ $chapter }</span> { $title }
-
-textbook-view-header-derived-from =
-  | Utworzone z <a href="{ $url }">{ $title }</a> przez <span class="book-authors">{ TAKE(50, $authors) }</span>
+textbook-view-header-derived-from-by = przez
 
 # TEXTBOOK VIEW - Metadata - src/scripts/modules/media/footer/metadata/metadata-template.html
 

--- a/src/scripts/modules/media/header/header-template.html
+++ b/src/scripts/modules/media/header/header-template.html
@@ -14,16 +14,18 @@
     {{/if}}
 
     <div class="title">
-      <h2 data-l10n-id="textbook-view-header-{{#isnt status 'publishing'}}no-{{/isnt}}publishing{{#if chapter}}-chapter{{/if}}" data-l10n-args='{"chapter":"{{chapter}}","title":"{{safeQuotes pageTitle}}"}'>
+      <h2>
         {{#is status 'publishing'}}
-          <span class="label label-info">publishing</span>
+          <span data-l10n-id="textbook-view-header-publishing" class="label label-info">publishing</span>
         {{/is}}
         {{#if chapter}}<span class="title-chapter">{{chapter}}</span>{{/if}}
         {{{pageTitle}}}
       </h2>
       {{#if currentPage.parent.id}}
-        <span data-l10n-id="textbook-view-header-derived-from" data-l10n-args='{"url":"/contents/{{currentPage.parent.id}}@{{currentPage.parent.version}}","title":"{{safeQuotes currentPage.parent.title}}","authors": {{toJSON (mapField currentPage.parent.authors "fullname")}} }'>
-          Derived from <a href="/contents/{{currentPage.parent.id}}@{{currentPage.parent.version}}">{{currentPage.parent.title}}</a> by
+        <span>
+          <span data-l10n-id="textbook-view-header-derived-from">Derived from</span>
+          <a href="/contents/{{currentPage.parent.id}}@{{currentPage.parent.version}}">{{currentPage.parent.title}}</a>
+          <span data-l10n-id="textbook-view-header-derived-from-by">by</span>
           <span class="book-authors">
             {{#each currentPage.parent.authors}}
               <span class="list-comma">{{fullname}}</span>

--- a/src/scripts/modules/media/title/title-template.html
+++ b/src/scripts/modules/media/title/title-template.html
@@ -17,13 +17,15 @@
     <div class="title">
       <h1 class="large-header">
         {{#is status 'publishing'}}
-          <span class="label label-info" data-l10n-id="textbook-view-publishing" data-l10n-args='{"title":"{{title}}"}'>publishing {{{title}}}</span>
+        <span class="label label-info"><span data-l10n-id="textbook-view-publishing">publishing</span> {{{title}}}</span>
         {{else}}
           {{{title}}}
         {{/is}}
       </h1>
       {{#if parent.id}}
-        <span data-l10n-id="textbook-view-derived-from" data-l10n-args='{"url":"/contents/{{parent.id}}@{{parent.version}}", "title":"{{parent.title}}","authors": {{toJSON (mapField parent.authors "fullname")}} }'>Derived from <a href="/contents/{{parent.id}}@{{parent.version}}">{{parent.title}}</a> by
+      <span data-l10n-id="textbook-view-derived-from">Derived from</span>
+          <a href="/contents/{{parent.id}}@{{parent.version}}">{{parent.title}}</a>
+          <span data-l10n-id="textbook-view-derived-from-by">by</span>
           <span class="collection-authors">
             {{~#each parent.authors}}
               <span class="list-comma">{{fullname}}</span>


### PR DESCRIPTION
Baking files now adds markup to most page titles (we include the section number and spacer in spans). This is escaped when passed via `data-l10n-args` to the ftl translation templates, and ends up displayed as escaped markup, as seen here: 
![screenshot from 2017-04-24 15-56-24](https://cloud.githubusercontent.com/assets/253212/25358338/b116e1fc-2906-11e7-9aeb-86490e02aea1.png)

This patch converts some translations to not pass the page title, at the possible expense if less flexible translations. This is a WIP, since I have found more cases of title passed where I have not changed it. In general, if there's a single translated word or phrase followed by the content title, I'd suggest we instead of passing the title through l10n, just add a level of span around the translated bit.

Same page, with this patch:
![screenshot from 2017-04-24 15-56-49](https://cloud.githubusercontent.com/assets/253212/25358444/0f4475c8-2907-11e7-881f-718b306fcf4f.png)

Fixes Connexions/cnx-rulesets#171