### PR TITLE
dont need the init since the documentReady pr has been merged

### DIFF
--- a/src/scripts/config.js
+++ b/src/scripts/config.js
@@ -176,14 +176,7 @@
 
       l20n: {
         exports: 'L20n',
-        deps: ['templatePolyfill', 'babelPolyfill', 'customEventPolyfill'],
-        init: function () {
-          // work-around until https://github.com/katalysteducation/l20n.js/pull/1 is merged.
-          document.l10n.connectRoot(document.documentElement);
-          document.l10n.translateDocument().then(function () {
-            window.addEventListener('languagechange', document.l10n);
-          });
-        }
+        deps: ['templatePolyfill', 'babelPolyfill', 'customEventPolyfill']
       }
     },
 


### PR DESCRIPTION
https://github.com/katalysteducation/l20n.js/pull/1 merged, this is no longer needed, and may be causing problems sometimes on qa.