### PR TITLE
Clean up the setup script

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -25,6 +25,3 @@ then
   >&2 echo "Using node: $(node --version)"
   >&2 echo "Using npm: $(npm --version)"
 fi
-
->&2 echo "==> Installing package dependencies"
-npm install || exit 1

--- a/script/build
+++ b/script/build
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+>&2 echo "==> Building dist/"
+npm run-script dist || exit 1

--- a/script/setup
+++ b/script/setup
@@ -2,5 +2,5 @@
 
 ./script/bootstrap || exit 1
 
->&2 echo "==> Building dist/"
-npm run-script dist || exit 1
+>&2 echo "==> Installing package dependencies"
+npm install || exit 1

--- a/src/scripts/settings.js
+++ b/src/scripts/settings.js
@@ -10,7 +10,7 @@
 
       // Hostname and port for the cnx-archive server
       cnxarchive: {
-        host: 'archive-cte-cnx-dev.cnx.org',
+        host: 'archive.cnx.org',
         port: 80
       },
 


### PR DESCRIPTION
This changes `./script/setup` to just install the dependencies. Previously the script would also build the `./dist/` directory but that has been moved to `./script/build`.