### PR TITLE
Fix the bug about orgnization's name in the footer

### DIFF
--- a/src/scripts/modules/footer/footer-template.html
+++ b/src/scripts/modules/footer/footer-template.html
@@ -8,7 +8,7 @@
       </ul>
     </div>
     <div data-l10n-id="all-footer-support">
-      Supported by William &amp; Flora Hewlett Foundation, Bill &amp; Melinda Gates Foundation, 20 Million Minds Foundation, Maxfield Foundation, Open Society Foundations, and Rice University. Powered by OpenStax CNX.
+      Supported by William &amp; Flora Hewlett Foundation, Bill &amp; Melinda Gates Foundation, Michelson 20MM Foundation, Maxfield Foundation, Open Society Foundations, and Rice University. Powered by OpenStax CNX.
     </div>
     <div data-l10n-id="all-footer-ap">
       Advanced Placement<sup>&reg;</sup> and AP<sup>&reg;</sup> are trademarks registered and/or owned by the College Board, which was not involved in the production of, and does not endorse, this site.


### PR DESCRIPTION
The footer of CNX lists 20 Million Minds Foundation, but that organization is now called the Michelson 20MM Foundation. Therefore I corrected it by replacing the old name with the new one.