### PR TITLE
Fix the unaccessibility of show solution button

### DIFF
--- a/src/scripts/pages/app/modals/legacy-template.html
+++ b/src/scripts/pages/app/modals/legacy-template.html
@@ -14,7 +14,7 @@
           <div class="form-group">
             <div class="checkbox">
               <label>
-                <input type="checkbox" data-l10n-id="legacy-template-remind-again"> <span data-l10n-id="legacy-template-remind-again">Don't remind me again</span>
+                <input type="checkbox" value="show solution" data-l10n-id="legacy-template-remind-again"> <span data-l10n-id="legacy-template-remind-again">Don't remind me again</span>
               </label>
             </div>
           </div>


### PR DESCRIPTION
When navigating to a button that can show solution, descriptive text doen't appear. Therefore I fix this issue by giving a value attribute to the tag <input class="checkbox"> .