### PR TITLE
strip HTML tags from the page title

### DIFF
--- a/src/locale/en-US/dictionary.ftl
+++ b/src/locale/en-US/dictionary.ftl
@@ -687,15 +687,6 @@ textbook-view-btn-get-this-page = Get This Page!
 
 textbook-view-summary = Summary
 
-textbook-view-header-publishing = <span class="label label-info">publishing</span> { $title }
-
-textbook-view-header-publishing-chapter =
-  | <span class="label label-info">publishing</span> <span class="title-chapter">{ $chapter }</span> { $title }
-
-textbook-view-header-no-publishing = { $title }
-
-textbook-view-header-no-publishing-chapter = <span class="title-chapter">{ $chapter }</span> { $title }
-
 textbook-view-header-derived-from =
   | Derived from <a href="{ $url }">{ $title }</a> by <span class="book-authors">{ TAKE(50, $authors) }</span>
 

--- a/src/locale/pl/dictionary.ftl
+++ b/src/locale/pl/dictionary.ftl
@@ -692,15 +692,6 @@ textbook-view-btn-get-this-page = Weź tę stronę!
 
 textbook-view-summary = Podsumowanie
 
-textbook-view-header-publishing = <span class="label label-info">publikujesz</span> { $title }
-
-textbook-view-header-publishing-chapter =
-  | <span class="label label-info">publikujesz</span> <span class="title-chapter">{ $chapter }</span> { $title }
-
-textbook-view-header-no-publishing = { $title }
-
-textbook-view-header-no-publishing-chapter = <span class="title-chapter">{ $chapter }</span> { $title }
-
 textbook-view-header-derived-from =
   | Utworzone z <a href="{ $url }">{ $title }</a> przez <span class="book-authors">{ TAKE(50, $authors) }</span>
 

--- a/src/scripts/helpers/backbone/views/base.coffee
+++ b/src/scripts/helpers/backbone/views/base.coffee
@@ -5,6 +5,7 @@ define (require) ->
   settings = require('settings')
   linksHelper = require('cs!helpers/links.coffee')
   locale = require('cs!helpers/locale.coffee')
+  stripTags = require('cs!../../strip-tags.coffee')
 
   dispose = (obj) ->
     delete obj.parent
@@ -77,12 +78,12 @@ define (require) ->
         historyPage = linksHelper.getCurrentPathComponents().page
 
       if @pageTitle
-        pageTitle = @pageTitle.replace(/<\/?[^>]+(>|$)/g, '') # Strip tags for baked HTML titles
-        document.title = pageTitle + settings.titleSuffix
+        strippedPageTitle = stripTags(@pageTitle)
+        document.title = strippedPageTitle + settings.titleSuffix
 
         if not isBook
           title = document.querySelector('title')
-          title.dataset.l10nId = pageTitle
+          title.dataset.l10nId = strippedPageTitle
 
           if @pageTitleArgs
             title.dataset.l10nArgs = JSON.stringify(_.extend({

--- a/src/scripts/helpers/backbone/views/base.coffee
+++ b/src/scripts/helpers/backbone/views/base.coffee
@@ -77,11 +77,12 @@ define (require) ->
         historyPage = linksHelper.getCurrentPathComponents().page
 
       if @pageTitle
-        document.title = @pageTitle + settings.titleSuffix
+        pageTitle = @pageTitle.replace(/<\/?[^>]+(>|$)/g, '') # Strip tags for baked HTML titles
+        document.title = pageTitle + settings.titleSuffix
 
         if not isBook
           title = document.querySelector('title')
-          title.dataset.l10nId = @pageTitle
+          title.dataset.l10nId = pageTitle
 
           if @pageTitleArgs
             title.dataset.l10nArgs = JSON.stringify(_.extend({

--- a/src/scripts/helpers/handlebars/stripTags.coffee
+++ b/src/scripts/helpers/handlebars/stripTags.coffee
@@ -1,5 +1,6 @@
 define (require) ->
   Handlebars = require('hbs/handlebars')
+  stripTags = require('cs!../strip-tags.coffee')
 
   Handlebars.registerHelper 'stripTags', (str) ->
-    return str.replace(/<\/?[^>]+(>|$)/g, '')
+    return stripTags(str)

--- a/src/scripts/helpers/handlebars/stripTags.coffee
+++ b/src/scripts/helpers/handlebars/stripTags.coffee
@@ -1,0 +1,5 @@
+define (require) ->
+  Handlebars = require('hbs/handlebars')
+
+  Handlebars.registerHelper 'stripTags', (str) ->
+    return str.replace(/<\/?[^>]+(>|$)/g, '')

--- a/src/scripts/helpers/strip-tags.coffee
+++ b/src/scripts/helpers/strip-tags.coffee
@@ -1,0 +1,10 @@
+define (require) ->
+  # Used for stripping HTML tags from the page title
+  SCRATCH_DIV = document.createElement('div')
+
+  # Strip tags for baked HTML titles
+  return (htmlText) ->
+    SCRATCH_DIV.innerHTML = htmlText
+    htmlText = SCRATCH_DIV.textContent
+    SCRATCH_DIV.innerHTML = '' # So the elements can be GC'd
+    htmlText

--- a/src/scripts/modules/media/header/header-template.html
+++ b/src/scripts/modules/media/header/header-template.html
@@ -14,15 +14,12 @@
     {{/if}}
 
     <div class="title">
-      <h2 data-l10n-id="textbook-view-header-{{#isnt status 'publishing'}}no-{{/isnt}}publishing{{#if chapter}}-chapter{{/if}}" data-l10n-args='{"chapter":"{{chapter}}","title":"{{stripTags pageTitle}}"}'>
-        {{#is status 'publishing'}}
-          <span class="label label-info">publishing</span>
-        {{/is}}
+      <h2>
         {{#if chapter}}<span class="title-chapter">{{chapter}}</span>{{/if}}
         {{{pageTitle}}}
       </h2>
       {{#if currentPage.parent.id}}
-        <span data-l10n-id="textbook-view-header-derived-from" data-l10n-args='{"url":"/contents/{{currentPage.parent.id}}@{{currentPage.parent.version}}","title":"{{safeQuotes currentPage.parent.title}}","authors": {{toJSON (mapField currentPage.parent.authors "fullname")}} }'>
+        <span data-l10n-id="textbook-view-header-derived-from" data-l10n-args='{"url":"/contents/{{currentPage.parent.id}}@{{currentPage.parent.version}}","title":"{{stripTags currentPage.parent.title}}","authors": {{toJSON (mapField currentPage.parent.authors "fullname")}} }'>
           Derived from <a href="/contents/{{currentPage.parent.id}}@{{currentPage.parent.version}}">{{currentPage.parent.title}}</a> by
           <span class="book-authors">
             {{#each currentPage.parent.authors}}

--- a/src/scripts/modules/media/header/header-template.html
+++ b/src/scripts/modules/media/header/header-template.html
@@ -14,7 +14,7 @@
     {{/if}}
 
     <div class="title">
-      <h2 data-l10n-id="textbook-view-header-{{#isnt status 'publishing'}}no-{{/isnt}}publishing{{#if chapter}}-chapter{{/if}}" data-l10n-args='{"chapter":"{{chapter}}","title":"{{safeQuotes pageTitle}}"}'>
+      <h2 data-l10n-id="textbook-view-header-{{#isnt status 'publishing'}}no-{{/isnt}}publishing{{#if chapter}}-chapter{{/if}}" data-l10n-args='{"chapter":"{{chapter}}","title":"{{stripTags pageTitle}}"}'>
         {{#is status 'publishing'}}
           <span class="label label-info">publishing</span>
         {{/is}}


### PR DESCRIPTION
As a stopgap solution while waiting for https://github.com/projectfluent/fluent.js/issues/37 to be resolved this strips the HTML tags out of the `<title>` and the Page Title.

/cc @reedstrm 