### PR TITLE
Fix the empty button issue

### DIFF
--- a/src/scripts/modules/media/body/body.coffee
+++ b/src/scripts/modules/media/body/body.coffee
@@ -157,7 +157,7 @@ define (require) ->
           .wrapInner('<section class="ui-body">')
           .prepend('''
             <div class="ui-toggle-wrapper">
-              <button class="btn-link ui-toggle" title="Show/Hide Solution"></button>
+              <button class="btn-link ui-toggle" title="Show/Hide Solution" aria-label="show/hide solution"></button>
             </div>''')
 
           $temp.find('figure:has(> figcaption)').addClass('ui-has-child-figcaption')


### PR DESCRIPTION
When navigating to a button, descriptive text didn't present to screen reader users to indicate the function of the button. Therefore I fixed it by adding a descriptive text.