### PR TITLE
Follow Up with Pull Request #1534

### DIFF
--- a/src/scripts/modules/media/body/body.coffee
+++ b/src/scripts/modules/media/body/body.coffee
@@ -157,7 +157,7 @@ define (require) ->
           .wrapInner('<section class="ui-body">')
           .prepend('''
             <div class="ui-toggle-wrapper">
-              <button class="btn-link ui-toggle" title="Show/Hide Solution"></button>
+              <button class="btn-link ui-toggle" title="Show/Hide Solution" aria-label="click to show solution, click again to hide"></button>
             </div>''')
 
           $temp.find('figure:has(> figcaption)').addClass('ui-has-child-figcaption')


### PR DESCRIPTION
When navigating to a button, no descriptive text is presented to screen reader users to indicate the function of the button. Therefore I fixed it by making the aria-expanded as true/false when the solution shows/hide.