### PR TITLE
Fix the Empty Button bug

### DIFF
--- a/src/scripts/modules/media/body/body.coffee
+++ b/src/scripts/modules/media/body/body.coffee
@@ -469,7 +469,12 @@ define (require) ->
     toggleSolution: (e) ->
       $solution = $(e.currentTarget).closest('.solution, [data-type="solution"]')
       $solution.toggleClass('ui-solution-visible')
-
+      if $solution.hasClass('ui-solution-visible')
+        $solution.attr('aria-expanded',true)
+        $solution.attr('aria-label',"hide solution")
+      else
+        $solution.attr('aria-expanded',false)
+        $solution.attr('aria-label',"show solution")
     onEditable: () -> @$el.find('.media-body').addClass('draft')
 
     onUneditable: () ->


### PR DESCRIPTION
When navigating to a button, descriptive text didn't present to screen reader users to indicate the function of the button.
Therefore I fixed this bug by setting the aria-label according to the status of the attribute aria-expanded.