### PR TITLE
In book search

### DIFF
--- a/src/scripts/modules/media/nav/nav.coffee
+++ b/src/scripts/modules/media/nav/nav.coffee
@@ -122,8 +122,13 @@ define (require) ->
 
     enableClearSearch: ->
       @$el.find('.searchbar > .fa').
-      removeClass('fa-search').
+      removeClass('fa-spinner fa-spin load-search').
       addClass('fa-times-circle clear-search')
+
+    enableLoadSearch: ->
+      @$el.find('.searchbar > .fa').
+      removeClass('fa-search').
+      addClass('fa-spinner fa-spin load-search')
 
     handleSearchInput: (event) ->
       if (event.keyCode == 13 and event.target.value?)
@@ -136,6 +141,9 @@ define (require) ->
           bookId: "#{@model.get('id')}@#{@model.get('version')}",
           query: @searchTerm
         }
+        # before the search has loaded
+        @enableLoadSearch()
+        # after the search has completed
         BookSearchResults.fetch(options).done((data) =>
           if not @tocIsOpen
             @toggleContents()

--- a/src/scripts/modules/media/nav/nav.less
+++ b/src/scripts/modules/media/nav/nav.less
@@ -62,6 +62,10 @@
         &.clear-search {
           cursor: pointer;
         }
+        &.load-search {
+          cursor: pointer;
+        }
+
       }
     }
 
@@ -82,7 +86,7 @@
           .flex(1; 1; 75%);
         }
 
-        > .progress {          
+        > .progress {
           margin-top: 1.4rem;
           margin-bottom: 0;
           height: @progress-height;

--- a/src/scripts/modules/media/tabs/contents/contents-template.html
+++ b/src/scripts/modules/media/tabs/contents/contents-template.html
@@ -1,13 +1,15 @@
   {{#if editable}}
     <button type="button" class="add btn btn-default"><span data-l10n-id="textbook-editor-contents-add-button">Add</span> <span class="caret"></span></button>
   {{/if}}
-  <div class="clear-results">
-    <a class="clear-results" href="#">
-      <span class="fa fa-arrow-circle-left"></span>
-      <span data-l10n-id="textbook-editor-contents-back-to-table">Back to Table of Contents</span>
-    </a>
-  </div>
-  <div class="result-count" data-l10n-id="textbook-editor-contents-results-matches" data-l10n-args='{"hits":{{resultCount}} }'>{{resultCountText}}</div>
+  {{#if resultCountText}}
+    <div class="clear-results">
+      <a class="clear-results" href="#">
+        <span class="fa fa-arrow-circle-left"></span>
+        <span data-l10n-id="textbook-editor-contents-back-to-table">Back to Table of Contents</span>
+      </a>
+    </div>
+    <div class="result-count" data-l10n-id="textbook-editor-contents-results-matches" data-l10n-args='{"hits":{{resultCount}} }'>{{resultCountText}}</div>
+  {{/if}}
   <div class="toc">
     {{! TocView}}
   </div>

--- a/src/scripts/modules/media/tabs/contents/contents-template.html
+++ b/src/scripts/modules/media/tabs/contents/contents-template.html
@@ -1,15 +1,13 @@
   {{#if editable}}
     <button type="button" class="add btn btn-default"><span data-l10n-id="textbook-editor-contents-add-button">Add</span> <span class="caret"></span></button>
   {{/if}}
-  {{#if resultCount}}
-    <div class="clear-results">
-      <a class="clear-results" href="#">
-        <span class="fa fa-arrow-circle-left"></span>
-        <span data-l10n-id="textbook-editor-contents-back-to-table">Back to Table of Contents</span>
-      </a>
-    </div>
-    <div class="result-count" data-l10n-id="textbook-editor-contents-results-matches" data-l10n-args='{"hits":{{resultCount}} }'>{{resultCountText}}</div>
-  {{/if}}
+  <div class="clear-results">
+    <a class="clear-results" href="#">
+      <span class="fa fa-arrow-circle-left"></span>
+      <span data-l10n-id="textbook-editor-contents-back-to-table">Back to Table of Contents</span>
+    </a>
+  </div>
+  <div class="result-count" data-l10n-id="textbook-editor-contents-results-matches" data-l10n-args='{"hits":{{resultCount}} }'>{{resultCountText}}</div>
   <div class="toc">
     {{! TocView}}
   </div>


### PR DESCRIPTION
Fixed regression so that when there are no results it is reported to the user
Added a loading icon to the in book search

Loading icon looks like this:
<img width="355" alt="screen shot 2017-06-06 at 2 06 12 pm" src="https://user-images.githubusercontent.com/5431974/26847090-64cecef4-4ac1-11e7-9480-96c1c5ad6575.png">

 But could easily be changed to this one: (not sure which goes better with the ux, and the openstax brand look. Fred and Nathan said there wasn't an openstax standard)
<img width="382" alt="screen shot 2017-06-06 at 2 08 12 pm" src="https://user-images.githubusercontent.com/5431974/26847157-a6ec2278-4ac1-11e7-92a3-e4f4872eca64.png">


