### PR TITLE
Add additional navigation levels for the current table of contens

### DIFF
--- a/src/scripts/modules/media/body/body.coffee
+++ b/src/scripts/modules/media/body/body.coffee
@@ -152,6 +152,31 @@ define (require) ->
             # NOTE: `.toggleClass()` explicitly requires a `false` (not falsy) 2nd argument
             $el.toggleClass('ui-has-child-title', $title.length > 0)
 
+          # Create subtitles in each chapter with corresponding ids as their href
+          total_subtitle = $temp.find("[data-depth='1']")
+          total_id = total_subtitle.children('[data-type="title"]')
+          id_length = total_id.length
+          i = 0
+          slash_index = window.location.href.lastIndexOf("/")+1
+          real_href = window.location.pathname
+          if real_href.indexOf("#")!= -1
+            hash_index = real_href.indexOf("#")-1
+            real_href = real_href.substring(0,hash_index)
+          location = $('.table-of-contents [href$="'+real_href+'"]').children(".title")
+          location2 = $('.table-of-contents [href$="'+real_href+'"]').children(".chapter-number")
+          # Keep adding subtitles until all subtitles are added
+          if location.children("li").length < id_length
+            while i < id_length
+              c_index = i + 1
+              id = total_subtitle[i].id
+              hash_id = "#" + id
+              list = $("<li>")
+              list.text(location2[0].textContent + "."  + c_index + " " + total_id[i].textContent)
+              list.wrapInner('''<a href = ""></a>''')
+              list.children("a").attr("href", hash_id)
+              location.append(list)
+              i = i + 1
+
           # Wrap solutions in a div so "Show/Hide Solutions" work
           $temp.find('.exercise .solution, [data-type="exercise"] [data-type="solution"]')
           .wrapInner('<section class="ui-body">')
@@ -469,6 +494,12 @@ define (require) ->
     toggleSolution: (e) ->
       $solution = $(e.currentTarget).closest('.solution, [data-type="solution"]')
       $solution.toggleClass('ui-solution-visible')
+      if $solution.hasClass('ui-solution-visible')
+        $solution.attr('aria-expanded',true)
+        $solution.attr('aria-label',"hide solution")
+      else
+        $solution.attr('aria-expanded',false)
+        $solution.attr('aria-label',"show solution")
 
     onEditable: () -> @$el.find('.media-body').addClass('draft')
 

--- a/src/scripts/modules/media/tabs/contents/toc/page.coffee
+++ b/src/scripts/modules/media/tabs/contents/toc/page.coffee
@@ -53,6 +53,11 @@ define (require) ->
       e.stopPropagation()
 
       $link = $(e.currentTarget)
+      if $link[0].href.indexOf("#") > -1
+          index = $link[0].href.indexOf("#")
+          new_link =  $link[0].href.substring(index)
+          window.location.hash = new_link.substring(1)
+          return
       router.navigate $link.attr('href'), {trigger: false}, () => @trackNav()
       @model.get('book').setPage($link.data('page'))
 

--- a/src/scripts/modules/media/tabs/contents/toc/page.coffee
+++ b/src/scripts/modules/media/tabs/contents/toc/page.coffee
@@ -54,10 +54,10 @@ define (require) ->
 
       $link = $(e.currentTarget)
       if $link[0].href.indexOf("#") > -1
-          index = $link[0].href.indexOf("#")
-          new_link =  $link[0].href.substring(index)
-          window.location.hash = new_link.substring(1)
-          return
+        index = $link[0].href.indexOf("#")
+        new_link =  $link[0].href.substring(index)
+        window.location.hash = new_link.substring(1)
+        return
       router.navigate $link.attr('href'), {trigger: false}, () => @trackNav()
       @model.get('book').setPage($link.data('page'))
 


### PR DESCRIPTION
Currently the Table of contents on webview shows chapters, and the pages in those chapters. Most of those pages are quite long, with logical sections inside that are linkable, and potentially useful for assignments, etc. 