### PR TITLE
Link fix

### DIFF
--- a/src/scripts/helpers/links.coffee
+++ b/src/scripts/helpers/links.coffee
@@ -78,6 +78,8 @@ define (require) ->
     getCurrentPathComponents: () ->
       components = Backbone.history.fragment.match(@contentsLinkRegEx) or []
       path = components[0]
+      hash_path = window.location.hash
+      components[6] = hash_path
       if path?.slice(-1) is '/'
         path = path.slice(0, -1)
 
@@ -89,6 +91,7 @@ define (require) ->
         title: components[4]
         rawquery: components[5] or ''
         query: @serializeQuery(components[5] or '')
+        hash_path: components[6]
       }
 
     serializeQuery: (query) ->

--- a/src/scripts/modules/media/body/body.coffee
+++ b/src/scripts/modules/media/body/body.coffee
@@ -67,7 +67,7 @@ define (require) ->
       else
         pageId = 0
       currentRoute = Backbone.history.getFragment()
-      canonicalPath = linksHelper.getPath('contents', {model: @model, page: pageId}, [])+ window.location.hash
+      canonicalPath = linksHelper.getPath('contents', {model: @model, page: pageId}, []) + window.location.hash
       if (canonicalPath isnt "/#{currentRoute}")
         router.navigate(canonicalPath, {replace: true})
 

--- a/src/scripts/modules/media/body/body.coffee
+++ b/src/scripts/modules/media/body/body.coffee
@@ -67,7 +67,7 @@ define (require) ->
       else
         pageId = 0
       currentRoute = Backbone.history.getFragment()
-      canonicalPath = linksHelper.getPath('contents', {model: @model, page: pageId}, [])
+      canonicalPath = linksHelper.getPath('contents', {model: @model, page: pageId}, [])+ window.location.hash
       if (canonicalPath isnt "/#{currentRoute}")
         router.navigate(canonicalPath, {replace: true})
 

--- a/src/scripts/modules/media/media.coffee
+++ b/src/scripts/modules/media/media.coffee
@@ -200,7 +200,8 @@ define (require) ->
       qs = components.rawquery
 
       if title isnt components.title and not @model.isBook()
-        router.navigate("contents/#{components.uuid}#{components.version}/#{title}#{qs}", {replace: true})
+        router.navigate("contents/#{components.uuid}#{components.version}/\
+        #{title}#{components.hash_path}#{qs}", {replace: true})
 
     trackAnalytics: () ->
       # Track loading using the media's own analytics ID, if specified


### PR DESCRIPTION
Users want to link to paragraphs in Rewrite. The ids exist, but the URL gets rewritten after the pages loads and the id gets lost.