### PR TITLE
Make donation email address configurable

### DIFF
--- a/src/scripts/pages/donate/form/form-template.html
+++ b/src/scripts/pages/donate/form/form-template.html
@@ -15,7 +15,7 @@
     <input type="hidden" name="UPAY_SITE_ID" id="UPAY_SITE_ID" value="8" />
     <input type="hidden" name="Revenue_amount" id="Revenue_amount" value="0" />
     <input type="hidden" name="Donation_To" id="Donation_To" value="OpenStax CNX" />
-    <input type="hidden" name="TNE_Admin_Email" value="openstaxgiving@rice.edu" />
+    <input type="hidden" name="TNE_Admin_Email" value="{{donation}}" />
     <input type="hidden" name="Rice_Relate" id="Rice_Relation" value="Friend" />
     <input type="hidden" name="TNE_Customer_From" value="cnx@cnx.org" />
     <input type="hidden" name="TNE_Customer_Subject" value="OpenStax CNX Donation Receipt" />

--- a/src/scripts/pages/donate/form/form.coffee
+++ b/src/scripts/pages/donate/form/form.coffee
@@ -3,6 +3,7 @@ define (require) ->
   validationHelper = require('cs!helpers/validation')
   BaseView = require('cs!helpers/backbone/views/base')
   template = require('hbs!./form-template')
+  settings = require('settings')
   require('less!./form')
 
   countries = [
@@ -345,6 +346,8 @@ define (require) ->
         url = "#{location.protocol}//#{location.host}/donate"
         url += "/download/#{@uuid}/#{@type}" if @uuid and @type
         return url
+      donation: () ->
+        return settings.donation
 
     events:
       'submit form': 'onSubmit'

--- a/src/scripts/settings.js
+++ b/src/scripts/settings.js
@@ -38,6 +38,9 @@
       // Webmaster E-mail address
       webmaster: 'support@openstax.org',
 
+      // Donate E-mail address
+      donation: 'openstaxgiving@rice.edu',
+
       // Content shortcodes
       shortcodes: {
         'college-physics': '031da8d3-b525-429c-80cf-6c8ed997733a@8.1',


### PR DESCRIPTION
This allows email in the donation submission form to be changed via `settings.js`.

The email address in the "TNE_Admin_Email" field needs to be changed to openstaxgiving@rice.edu as opposed to invoices@cnx.org.

Also, this is the fix for webview only, I will have another pull request in the cnx-deploy .