### PR TITLE
fix note titles, make example & note styling consistent for baked books

### DIFF
--- a/src/scripts/modules/media/body/_make-block.less
+++ b/src/scripts/modules/media/body/_make-block.less
@@ -1,0 +1,46 @@
+// Skeleton for constructing the blockish elements
+// This contains all the selectors for the styling
+
+// Helper mixin for expanding all the selectors
+.make-block(@type) {
+  #blockish>.style(@type);
+
+  // There are 3 cases for a label:
+  // - none   : The attribute is not on the element so show the default label
+  // - empty  : The attribute is present and it is the empty string; the default label should be suppressed
+  // - custom : The attribute contains a custom string that should be displayed instead of the default label
+
+  // Puts in the text of the label. Depending on if there is a title
+  // it will be added either as a `:before` on the blockish element or on the title element
+  .format-label(@type; @label-type; @has-title) { }
+  .format-label(@type; none;        false) { #blockish>.default-label(@type; false); }
+  .format-label(@type; empty;       false) { } // Nothing will show up
+  .format-label(@type; custom;      false) { content: attr(data-label); }
+  .format-label(@type; none;        true)  { #blockish>.default-label(@type; true); }
+  .format-label(@type; empty;       true)  { } // Only the title will show up
+  .format-label(@type; custom;      true)  { content: attr(data-label-parent) ': '; }
+
+  // Add the label to the title element (if one exists) or to the blockish element
+  .place-label(@type; @label-type) {
+    // A title exists so style it and put the label in `.title::before`
+    // FIXME: Remove the following line.
+    // Aloha and webview have slightly different places for the title
+    &.ui-has-child-title > header > [data-type="title"],
+    &.ui-has-child-title > [data-type="title"],
+    &.ui-has-child-title > header > .title,
+    &.ui-has-child-title > header > .os-title,
+    &.ui-has-child-title > .title,
+    &.ui-has-child-title .solution > section > [data-type="solution-title"] {
+      #blockish>.title(@type);
+      &::before { display: none; }
+    }
+  }
+
+  // Decide which case of the label we are dealing with
+  &:not([data-label])                 { .place-label(@type; none); }
+  &[data-label='']                    { .place-label(@type; empty); }
+  &[data-label]:not([data-label=''])  { .place-label(@type; custom); }
+
+  // Style the Body
+  > section         { #blockish>.body(@type); }
+}

--- a/src/scripts/modules/media/body/body.coffee
+++ b/src/scripts/modules/media/body/body.coffee
@@ -140,9 +140,9 @@ define (require) ->
                     [data-type="example"], [data-type="exercise"], [data-type="note"]').each (index, el) ->
             $el = $(el)
             $contents = $el.contents().filter (i, node) ->
-              return !$(node).is('.title, [data-type="title"]')
+              return !$(node).is('.title, [data-type="title"], .os-title')
             $contents.wrapAll('<section>')
-            $title = $el.children('.title, [data-type="title"]')
+            $title = $el.children('.title, [data-type="title"], .os-title')
             $title.wrap('<header>')
             # Add an attribute for the parents' `data-label`
             # since CSS does not support `parent(attr(data-label))`.

--- a/src/scripts/modules/media/body/content-baked.less
+++ b/src/scripts/modules/media/body/content-baked.less
@@ -14,10 +14,17 @@ h6 {
 }
 
 ul, ol {
-  margin-top: 1rem;
-  margin-bottom: 0;
   color: @gray;
+  margin-bottom: 1rem;
+  margin-top: 1rem;
 }
+
+iframe {
+  display: block;
+  margin: 3rem auto;
+  width: 100%;
+}
+
 
 // It is already displayed at the top of the page in blue
 // the `>` is because collated titles (like Key Concepts) contain descendent
@@ -97,24 +104,31 @@ figure:not([data-orient="vertical"]) {
 #blockish {
 .style(note) {
   margin: 3rem 0;
-  padding: 1.5rem 1.5rem 1.5rem 1.5rem;
+  padding: 1.5rem;
   background-color: @gray-lightest;
-  border: 0.1rem solid @gray-lighter;
+  border: 0.2rem solid @gray-lighter;
 
   > p {
     margin-top: 0;
+  }
+
+  :last-child {
+    margin-bottom: 0;
   }
 }
 .title(note) {
   color: @gray;
   font-size: 1.5rem;
+  font-weight: bold;
   text-transform: uppercase;
   letter-spacing: 0.1rem;
   display: block;
   margin-bottom: 1rem;
   margin-top: 0;
   padding: 0rem 1.5rem 1rem 1.5rem;
-  border-bottom: 0.1rem solid @gray-lighter;
+  border-bottom: 0.2rem solid @gray-lighter;
+
+
 }
 .body(note) {
   border-top: none;
@@ -127,6 +141,11 @@ figure:not([data-orient="vertical"]) {
 
   ul {
     color: @gray;
+  }
+
+  > span[data-type="media"] {
+    display: block;
+    margin: 1rem 0;
   }
 }
 .style(example) { .style(note) }
@@ -194,7 +213,10 @@ h1.example-title .text {
 [data-type="example"],
 .example  { .make-block(example); }
 [data-type="abstract"],
-.abstract { .make-block(note); }
+.abstract {
+  .make-block(note);
+  color: @gray;
+}
 [data-type="problem"],
 [data-type="solution"],
 .problem,
@@ -217,10 +239,14 @@ h1.example-title .text {
 // Tables
 // --------------------------------------------------
 .os-table {
+  margin: @line-height-computed 0;
   table {
-     margin: @line-height-computed 0;
+     margin: 0;
   }
   .os-caption-container {
+    padding: 8px;
+    border-top: 0.1rem solid @gray-lighter;
+
     .os-title-label,
     .os-number {
       font-weight: bold;

--- a/src/scripts/modules/media/body/content-baked.less
+++ b/src/scripts/modules/media/body/content-baked.less
@@ -3,6 +3,8 @@
 //
 //     #content { @import 'this_file.less'; }
 
+@import '_make-block';
+
 h1,
 h2,
 h3,
@@ -157,52 +159,7 @@ figure:not([data-orient="vertical"]) {
 h1.example-title .text {
   padding-left: 1rem;
 }
-// Skeleton for constructing the blockish elements
-// This contains all the selectors for the styling
 
-// Helper mixin for expanding all the selectors
-.make-block(@type) {
-  #blockish>.style(@type);
-
-  // There are 3 cases for a label:
-  // - none   : The attribute is not on the element so show the default label
-  // - empty  : The attribute is present and it is the empty string; the default label should be suppressed
-  // - custom : The attribute contains a custom string that should be displayed instead of the default label
-
-  // Puts in the text of the label. Depending on if there is a title
-  // it will be added either as a `:before` on the blockish element or on the title element
-  .format-label(@type; @label-type; @has-title) { }
-  .format-label(@type; none;        false) { #blockish>.default-label(@type; false); }
-  .format-label(@type; empty;       false) { } // Nothing will show up
-  .format-label(@type; custom;      false) { content: attr(data-label); }
-  .format-label(@type; none;        true)  { #blockish>.default-label(@type; true); }
-  .format-label(@type; empty;       true)  { } // Only the title will show up
-  .format-label(@type; custom;      true)  { content: attr(data-label-parent) ': '; }
-
-  // Add the label to the title element (if one exists) or to the blockish element
-  .place-label(@type; @label-type) {
-    // A title exists so style it and put the label in `.title::before`
-    // FIXME: Remove the following line.
-    // Aloha and webview have slightly different places for the title
-    &.ui-has-child-title > header > [data-type="title"],
-    &.ui-has-child-title > [data-type="title"],
-    &.ui-has-child-title > header > .title,
-    &.ui-has-child-title > header > .os-title,
-    &.ui-has-child-title > .title,
-    &.ui-has-child-title .solution > section > [data-type="solution-title"] {
-      #blockish>.title(@type);
-      &::before { display: none; }
-    }
-  }
-
-  // Decide which case of the label we are dealing with
-  &:not([data-label])                 { .place-label(@type; none); }
-  &[data-label='']                    { .place-label(@type; empty); }
-  &[data-label]:not([data-label=''])  { .place-label(@type; custom); }
-
-  // Style the Body
-  > section         { #blockish>.body(@type); }
-}
 .exercise-number() {
   font-weight: bold;
   text-decoration: none;

--- a/src/scripts/modules/media/body/content-baked.less
+++ b/src/scripts/modules/media/body/content-baked.less
@@ -50,7 +50,7 @@ ul, ol {
 
 .os-figure {
   display: table;
-  margin: 1rem auto 0;
+  margin: 3rem auto;
   .os-caption-container {
     padding-top: 1rem;
     display: table-caption;
@@ -95,22 +95,43 @@ figure:not([data-orient="vertical"]) {
 // Slots for various blockish pieces of content (things with a label, title, and body)
 // This **ONLY** contains rules, no selectors.
 #blockish {
+.style(note) {
+  margin: 3rem 0;
+  padding: 1.5rem 1.5rem 1.5rem 1.5rem;
+  background-color: @gray-lightest;
+  border: 0.1rem solid @gray-lighter;
 
-  .style(example) {
-    margin-top: 5rem;
-    position: relative;
-   }
-  .title(example) {
-    font-size: 1em;
-    position: absolute;
-    top: -4rem;
-    left: 0em;
-    padding: 0.4em 1em;
-    font-weight: bold;
-    color: @gray-lightest;
-    background-color: @gray;
-    max-width: 100%;
+  > p {
+    margin-top: 0;
   }
+}
+.title(note) {
+  color: @gray;
+  font-size: 1.5rem;
+  text-transform: uppercase;
+  letter-spacing: 0.1rem;
+  display: block;
+  margin-bottom: 1rem;
+  margin-top: 0;
+  padding: 0rem 1.5rem 1rem 1.5rem;
+  border-bottom: 0.1rem solid @gray-lighter;
+}
+.body(note) {
+  border-top: none;
+  padding: 0rem 1.5rem;
+  background-color: @gray-lightest;
+
+  p {
+    margin: 0 0 1rem;
+  }
+
+  ul {
+    color: @gray;
+  }
+}
+.style(example) { .style(note) }
+.title(example) { .title(note) }
+.body(example) { .body(note) }
 }
 
 // TODO refactor this
@@ -122,36 +143,83 @@ h1.example-title .text {
 
 // Helper mixin for expanding all the selectors
 .make-block(@type) {
+  #blockish>.style(@type);
+
+  // There are 3 cases for a label:
+  // - none   : The attribute is not on the element so show the default label
+  // - empty  : The attribute is present and it is the empty string; the default label should be suppressed
+  // - custom : The attribute contains a custom string that should be displayed instead of the default label
+
+  // Puts in the text of the label. Depending on if there is a title
+  // it will be added either as a `:before` on the blockish element or on the title element
+  .format-label(@type; @label-type; @has-title) { }
+  .format-label(@type; none;        false) { #blockish>.default-label(@type; false); }
+  .format-label(@type; empty;       false) { } // Nothing will show up
+  .format-label(@type; custom;      false) { content: attr(data-label); }
+  .format-label(@type; none;        true)  { #blockish>.default-label(@type; true); }
+  .format-label(@type; empty;       true)  { } // Only the title will show up
+  .format-label(@type; custom;      true)  { content: attr(data-label-parent) ': '; }
 
   // Add the label to the title element (if one exists) or to the blockish element
   .place-label(@type; @label-type) {
-    // No title exists so style the blockish::before and put the label there
-    &:not(.ui-has-child-title) .example-title {
+    // A title exists so style it and put the label in `.title::before`
+    // FIXME: Remove the following line.
+    // Aloha and webview have slightly different places for the title
+    &.ui-has-child-title > header > [data-type="title"],
+    &.ui-has-child-title > [data-type="title"],
+    &.ui-has-child-title > header > .title,
+    &.ui-has-child-title > header > .os-title,
+    &.ui-has-child-title > .title,
+    &.ui-has-child-title .solution > section > [data-type="solution-title"] {
       #blockish>.title(@type);
-      .format-label(@type; @label-type; false);
+      &::before { display: none; }
     }
   }
 
+  // Decide which case of the label we are dealing with
+  &:not([data-label])                 { .place-label(@type; none); }
+  &[data-label='']                    { .place-label(@type; empty); }
+  &[data-label]:not([data-label=''])  { .place-label(@type; custom); }
+
+  // Style the Body
+  > section         { #blockish>.body(@type); }
 }
-
-
 .exercise-number() {
   font-weight: bold;
   text-decoration: none;
 }
 
-> :not(.os-eoc):not(.os-eob) [data-type="exercise"],
-> :not(.os-eoc):not(.os-eob) .exercise {
+[data-type="note"],
+.note     { .make-block(note); }
+[data-type="example"],
+.example  { .make-block(example); }
+[data-type="abstract"],
+.abstract { .make-block(note); }
+[data-type="problem"],
+[data-type="solution"],
+.problem,
+.solution {
+  padding: 0;
+}
+[data-type="solution"],
+.solution {
+  border-top: 0.1rem solid @gray-lighter;
 
-  .make-block(exercise);
-  .mixin-exercise();
-
+  section p,
+  section ul,
+  section ol,
+  section .os-table {
+    padding-left: 1.5rem;
+    padding-right: 1.5rem;
+  }
 }
 
-//
 // Tables
 // --------------------------------------------------
 .os-table {
+  table {
+     margin: @line-height-computed 0;
+  }
   .os-caption-container {
     .os-title-label,
     .os-number {

--- a/src/scripts/modules/media/body/content-common.less
+++ b/src/scripts/modules/media/body/content-common.less
@@ -526,62 +526,6 @@ div[data-type='list'][data-list-type]             { padding-left: 2.5rem; margin
 
 }
 
-// Skeleton for constructing the blockish elements
-// This contains all the selectors for the styling
-
-// Helper mixin for expanding all the selectors
-.make-block(@type) {
-  #blockish>.style(@type);
-
-  // There are 3 cases for a label:
-  // - none   : The attribute is not on the element so show the default label
-  // - empty  : The attribute is present and it is the empty string; the default label should be suppressed
-  // - custom : The attribute contains a custom string that should be displayed instead of the default label
-
-  // Puts in the text of the label. Depending on if there is a title
-  // it will be added either as a `:before` on the blockish element or on the title element
-  .format-label(@type; @label-type; @has-title) { }
-  .format-label(@type; none;        false) { #blockish>.default-label(@type; false); }
-  .format-label(@type; empty;       false) { } // Nothing will show up
-  .format-label(@type; custom;      false) { content: attr(data-label); }
-  .format-label(@type; none;        true)  { #blockish>.default-label(@type; true); }
-  .format-label(@type; empty;       true)  { } // Only the title will show up
-  .format-label(@type; custom;      true)  { content: attr(data-label-parent) ': '; }
-
-  // Add the label to the title element (if one exists) or to the blockish element
-  .place-label(@type; @label-type) {
-    // A title exists so style it and put the label in `.title::before`
-    // FIXME: Remove the following line.
-    // Aloha and webview have slightly different places for the title
-    &.ui-has-child-title > header > [data-type="title"],
-    &.ui-has-child-title > [data-type="title"],
-    &.ui-has-child-title > header > .title,
-    &.ui-has-child-title > .title {
-      #blockish>.title(@type);
-      &::before { .format-label(@type; @label-type; true); }
-    }
-    // // No title exists so style the blockish::before and put the label there
-    // &:not(.ui-has-child-title)::before {
-    //   #blockish>.title(@type);
-    //   .format-label(@type; @label-type; false);
-    // }
-  }
-
-  // Decide which case of the label we are dealing with
-  &:not([data-label])                 { .place-label(@type; none); }
-  &[data-label='']                    { .place-label(@type; empty); }
-  &[data-label]:not([data-label=''])  { .place-label(@type; custom); }
-
-  // Style the Body
-  > section         { #blockish>.body(@type); }
-}
-
-
-[data-type="note"],
-.note     { .make-block(note); }
-[data-type="example"],
-.example  { .make-block(example); }
-
 
 .mixin-exercise() {
   [data-type="problem"],

--- a/src/scripts/modules/media/body/content-raw.less
+++ b/src/scripts/modules/media/body/content-raw.less
@@ -3,6 +3,8 @@
 //
 //     #content { @import 'this_file.less'; }
 
+@import '_make-block';
+
 h1,
 h2,
 h3,
@@ -89,6 +91,10 @@ figure:not([data-orient="vertical"]) {
 
 }
 
+[data-type="note"],
+.note     { .make-block(note); }
+[data-type="example"],
+.example  { .make-block(example); }
 
 [data-type="exercise"],
 .exercise { .make-block(exercise); }

--- a/src/scripts/modules/media/body/content.less
+++ b/src/scripts/modules/media/body/content.less
@@ -3,12 +3,12 @@
 //
 //     #content { @import 'this_file.less'; }
 
-@import './content-common';
+@import 'content-common';
 
 &[data-is-baked="false"] {
-  @import 'content-raw.less';
+  @import 'content-raw';
 }
 
 &[data-is-baked="true"] {
-  @import 'content-baked.less';
+  @import 'content-baked';
 }


### PR DESCRIPTION
fix [#206](https://github.com/Connexions/cnx-recipes/issues/206)
Also, make note styling consistent across all note and example/exercise types