### PR TITLE
fix history issue, fix anchor link position - beware wall of text

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -25,7 +25,7 @@
     "select2": "4.0.3",
     "babel-polyfill": "0.0.1",
     "l20n": "https://github.com/katalysteducation/l20n.js.git#v4.0.15",
-    "concept-coach": "openstax/tutor-js#coach-20170308.c",
+    "concept-coach": "openstax/tutor-js#coach-20170630.a",
     "custom-event-polyfill": "0.3.0"
   },
   "devDependencies": {

--- a/bower.json
+++ b/bower.json
@@ -25,7 +25,7 @@
     "select2": "4.0.3",
     "babel-polyfill": "0.0.1",
     "l20n": "https://github.com/katalysteducation/l20n.js.git#v4.0.15",
-    "concept-coach": "openstax/tutor-js#coach-20170630.b",
+    "concept-coach": "openstax/tutor-js#coach-20170630.c",
     "custom-event-polyfill": "0.3.0"
   },
   "devDependencies": {

--- a/bower.json
+++ b/bower.json
@@ -25,7 +25,7 @@
     "select2": "4.0.3",
     "babel-polyfill": "0.0.1",
     "l20n": "https://github.com/katalysteducation/l20n.js.git#v4.0.15",
-    "concept-coach": "openstax/tutor-js#coach-20170630.a",
+    "concept-coach": "openstax/tutor-js#coach-20170630.b",
     "custom-event-polyfill": "0.3.0"
   },
   "devDependencies": {

--- a/src/scripts/modules/media/body/_make-block.less
+++ b/src/scripts/modules/media/body/_make-block.less
@@ -1,0 +1,46 @@
+// Skeleton for constructing the blockish elements
+// This contains all the selectors for the styling
+
+// Helper mixin for expanding all the selectors
+.make-block(@type) {
+  #blockish>.style(@type);
+
+  // There are 3 cases for a label:
+  // - none   : The attribute is not on the element so show the default label
+  // - empty  : The attribute is present and it is the empty string; the default label should be suppressed
+  // - custom : The attribute contains a custom string that should be displayed instead of the default label
+
+  // Puts in the text of the label. Depending on if there is a title
+  // it will be added either as a `:before` on the blockish element or on the title element
+  .format-label(@type; @label-type; @has-title) { }
+  .format-label(@type; none;        false) { #blockish>.default-label(@type; false); }
+  .format-label(@type; empty;       false) { } // Nothing will show up
+  .format-label(@type; custom;      false) { content: attr(data-label); }
+  .format-label(@type; none;        true)  { #blockish>.default-label(@type; true); }
+  .format-label(@type; empty;       true)  { } // Only the title will show up
+  .format-label(@type; custom;      true)  { content: attr(data-label-parent) ': '; }
+
+  // Add the label to the title element (if one exists) or to the blockish element
+  .place-label(@type; @label-type) {
+    // A title exists so style it and put the label in `.title::before`
+    // FIXME: Remove the following line.
+    // Aloha and webview have slightly different places for the title
+    &.ui-has-child-title > header > [data-type="title"],
+    &.ui-has-child-title > [data-type="title"],
+    &.ui-has-child-title > header > .title,
+    &.ui-has-child-title > header > .os-title,
+    &.ui-has-child-title > .title,
+    &.ui-has-child-title .solution > section > [data-type="solution-title"] {
+      #blockish>.title(@type);
+      &::before { display: none; }
+    }
+  }
+
+  // Decide which case of the label we are dealing with
+  &:not([data-label])                 { .place-label(@type; none); }
+  &[data-label='']                    { .place-label(@type; empty); }
+  &[data-label]:not([data-label=''])  { .place-label(@type; custom); }
+
+  // Style the Body
+  > section         { #blockish>.body(@type); }
+}

--- a/src/scripts/modules/media/body/body.coffee
+++ b/src/scripts/modules/media/body/body.coffee
@@ -449,8 +449,7 @@ define (require) ->
           @fragmentReloaded = true
 
           hash = window.location.hash
-          window.location.hash = ''
-          window.location.hash = hash
+          window.location.replace(hash)
 
       $target = $(window.location.hash)
       if $target.prop('tagName')?.toLowerCase() is 'iframe'

--- a/src/scripts/modules/media/body/body.coffee
+++ b/src/scripts/modules/media/body/body.coffee
@@ -452,10 +452,6 @@ define (require) ->
           window.location.hash = ''
           window.location.hash = hash
 
-          # scroll up by width of nav bar
-          # FIXME - make this dynamic
-          window.scrollBy(0, -145)
-
       $target = $(window.location.hash)
       if $target.prop('tagName')?.toLowerCase() is 'iframe'
         $target.on('load', jumpToHash)

--- a/src/scripts/modules/media/body/body.coffee
+++ b/src/scripts/modules/media/body/body.coffee
@@ -140,9 +140,9 @@ define (require) ->
                     [data-type="example"], [data-type="exercise"], [data-type="note"]').each (index, el) ->
             $el = $(el)
             $contents = $el.contents().filter (i, node) ->
-              return !$(node).is('.title, [data-type="title"]')
+              return !$(node).is('.title, [data-type="title"], .os-title')
             $contents.wrapAll('<section>')
-            $title = $el.children('.title, [data-type="title"]')
+            $title = $el.children('.title, [data-type="title"], .os-title')
             $title.wrap('<header>')
             # Add an attribute for the parents' `data-label`
             # since CSS does not support `parent(attr(data-label))`.

--- a/src/scripts/modules/media/body/body.coffee
+++ b/src/scripts/modules/media/body/body.coffee
@@ -136,8 +136,9 @@ define (require) ->
           $temp.children('[data-type="abstract"]').remove()
 
           # Wrap title and content elements in header and section elements, respectively
-          $temp.find('.example, .exercise, .note,
-                    [data-type="example"], [data-type="exercise"], [data-type="note"]').each (index, el) ->
+          $temp.find('.example, .exercise, .note, .abstract,
+                    [data-type="example"], [data-type="exercise"],
+                    [data-type="note"], [data-type="abstract"]').each (index, el) ->
             $el = $(el)
             $contents = $el.contents().filter (i, node) ->
               return !$(node).is('.title, [data-type="title"], .os-title')

--- a/src/scripts/modules/media/body/body.coffee
+++ b/src/scripts/modules/media/body/body.coffee
@@ -447,6 +447,7 @@ define (require) ->
       jumpToHash = () =>
         if currentPage.get('loaded') and not @fragmentReloaded and window.location.hash
           @fragmentReloaded = true
+
           hash = window.location.hash
           window.location.hash = ''
           window.location.hash = hash

--- a/src/scripts/modules/media/body/body.coffee
+++ b/src/scripts/modules/media/body/body.coffee
@@ -69,7 +69,8 @@ define (require) ->
       currentRoute = Backbone.history.getFragment()
       canonicalPath = linksHelper.getPath('contents', {model: @model, page: pageId}, []) + window.location.hash
       if (canonicalPath isnt "/#{currentRoute}")
-        router.navigate(canonicalPath, {replace: true})
+        # replace previous URL with the canonical path
+        history.replaceState({}, @model.get('title'), canonicalPath)
 
     updateTeacher: ($temp = @$el) ->
       $els = $temp.find('.os-teacher')
@@ -81,7 +82,8 @@ define (require) ->
 
     goToPage: (pageNumber, href) ->
       @model.setPage(pageNumber)
-      router.navigate href, {trigger: false}, => @parent.parent.parent.trackAnalytics()
+
+      router.navigate href, {trigger: true, replace: false}, => @parent.parent.parent.trackAnalytics()
 
     getCoach: ->
       moduleUUID = @model.getUuid()?.split('?')[0]
@@ -440,8 +442,8 @@ define (require) ->
         @jaxing = false
         @processCoachMath?()
 
-      # Update the hash fragment after the content has loaded
-      # to force the browser window to find the intended content
+      # Clear and replace the hash fragment after the content has loaded
+      # to force the browser window to find the intended content (as a side effect)
       jumpToHash = () =>
         if currentPage.get('loaded') and not @fragmentReloaded and window.location.hash
           @fragmentReloaded = true
@@ -449,11 +451,16 @@ define (require) ->
           window.location.hash = ''
           window.location.hash = hash
 
+          # scroll up by width of nav bar
+          # FIXME - make this dynamic
+          window.scrollBy(0, -145)
+
       $target = $(window.location.hash)
       if $target.prop('tagName')?.toLowerCase() is 'iframe'
         $target.on('load', jumpToHash)
       else
         jumpToHash()
+
 
     changePage: (e) ->
       # Don't intercept cmd/ctrl-clicks intended to open a link in a new tab

--- a/src/scripts/modules/media/body/content-baked.less
+++ b/src/scripts/modules/media/body/content-baked.less
@@ -3,6 +3,8 @@
 //
 //     #content { @import 'this_file.less'; }
 
+@import '_make-block';
+
 h1,
 h2,
 h3,
@@ -14,10 +16,17 @@ h6 {
 }
 
 ul, ol {
-  margin-top: 1rem;
-  margin-bottom: 0;
   color: @gray;
+  margin-bottom: 1rem;
+  margin-top: 1rem;
 }
+
+iframe {
+  display: block;
+  margin: 3rem auto;
+  width: 100%;
+}
+
 
 // It is already displayed at the top of the page in blue
 // the `>` is because collated titles (like Key Concepts) contain descendent
@@ -50,7 +59,7 @@ ul, ol {
 
 .os-figure {
   display: table;
-  margin: 1rem auto 0;
+  margin: 3rem auto;
   .os-caption-container {
     padding-top: 1rem;
     display: table-caption;
@@ -95,64 +104,106 @@ figure:not([data-orient="vertical"]) {
 // Slots for various blockish pieces of content (things with a label, title, and body)
 // This **ONLY** contains rules, no selectors.
 #blockish {
+.style(note) {
+  margin: 3rem 0;
+  padding: 1.5rem;
+  background-color: @gray-lightest;
+  border: 0.2rem solid @gray-lighter;
 
-  .style(example) {
-    margin-top: 5rem;
-    position: relative;
-   }
-  .title(example) {
-    font-size: 1em;
-    position: absolute;
-    top: -4rem;
-    left: 0em;
-    padding: 0.4em 1em;
-    font-weight: bold;
-    color: @gray-lightest;
-    background-color: @gray;
-    max-width: 100%;
+  > p {
+    margin-top: 0;
   }
+
+  :last-child {
+    margin-bottom: 0;
+  }
+}
+.title(note) {
+  color: @gray;
+  font-size: 1.5rem;
+  font-weight: bold;
+  text-transform: uppercase;
+  letter-spacing: 0.1rem;
+  display: block;
+  margin-bottom: 1rem;
+  margin-top: 0;
+  padding: 0rem 1.5rem 1rem 1.5rem;
+  border-bottom: 0.2rem solid @gray-lighter;
+
+
+}
+.body(note) {
+  border-top: none;
+  padding: 0rem 1.5rem;
+  background-color: @gray-lightest;
+
+  p {
+    margin: 0 0 1rem;
+  }
+
+  ul {
+    color: @gray;
+  }
+
+  > span[data-type="media"] {
+    display: block;
+    margin: 1rem 0;
+  }
+}
+.style(example) { .style(note) }
+.title(example) { .title(note) }
+.body(example) { .body(note) }
 }
 
 // TODO refactor this
 h1.example-title .text {
   padding-left: 1rem;
 }
-// Skeleton for constructing the blockish elements
-// This contains all the selectors for the styling
-
-// Helper mixin for expanding all the selectors
-.make-block(@type) {
-
-  // Add the label to the title element (if one exists) or to the blockish element
-  .place-label(@type; @label-type) {
-    // No title exists so style the blockish::before and put the label there
-    &:not(.ui-has-child-title) .example-title {
-      #blockish>.title(@type);
-      .format-label(@type; @label-type; false);
-    }
-  }
-
-}
-
 
 .exercise-number() {
   font-weight: bold;
   text-decoration: none;
 }
 
-> :not(.os-eoc):not(.os-eob) [data-type="exercise"],
-> :not(.os-eoc):not(.os-eob) .exercise {
+[data-type="note"],
+.note     { .make-block(note); }
+[data-type="example"],
+.example  { .make-block(example); }
+[data-type="abstract"],
+.abstract {
+  .make-block(note);
+  color: @gray;
+}
+[data-type="problem"],
+[data-type="solution"],
+.problem,
+.solution {
+  padding: 0;
+}
+[data-type="solution"],
+.solution {
+  border-top: 0.1rem solid @gray-lighter;
 
-  .make-block(exercise);
-  .mixin-exercise();
-
+  section p,
+  section ul,
+  section ol,
+  section .os-table {
+    padding-left: 1.5rem;
+    padding-right: 1.5rem;
+  }
 }
 
-//
 // Tables
 // --------------------------------------------------
 .os-table {
+  margin: @line-height-computed 0;
+  table {
+     margin: 0;
+  }
   .os-caption-container {
+    padding: 8px;
+    border-top: 0.1rem solid @gray-lighter;
+
     .os-title-label,
     .os-number {
       font-weight: bold;

--- a/src/scripts/modules/media/body/content-baked.less
+++ b/src/scripts/modules/media/body/content-baked.less
@@ -180,16 +180,21 @@ h1.example-title .text {
 .solution {
   padding: 0;
 }
-[data-type="solution"],
-.solution {
-  border-top: 0.1rem solid @gray-lighter;
+// solutions of notes, exercises, and examples have a top-border to separate the solution
+[data-type="note"],
+[data-type="exercise"],
+[data-type="example"] {
+  [data-type="solution"],
+  .solution {
+    border-top: 0.1rem solid @gray-lighter;
 
-  section p,
-  section ul,
-  section ol,
-  section .os-table {
-    padding-left: 1.5rem;
-    padding-right: 1.5rem;
+    section p,
+    section ul,
+    section ol,
+    section .os-table {
+      padding-left: 1.5rem;
+      padding-right: 1.5rem;
+    }
   }
 }
 

--- a/src/scripts/modules/media/body/content-baked.less
+++ b/src/scripts/modules/media/body/content-baked.less
@@ -141,7 +141,7 @@ figure:not([data-orient="vertical"]) {
     margin: 0 0 1rem;
   }
 
-  ul {
+  ul,ol {
     color: @gray;
   }
 
@@ -170,10 +170,7 @@ h1.example-title .text {
 [data-type="example"],
 .example  { .make-block(example); }
 [data-type="abstract"],
-.abstract {
-  .make-block(note);
-  color: @gray;
-}
+.abstract { .make-block(note); }
 [data-type="problem"],
 [data-type="solution"],
 .problem,
@@ -195,6 +192,21 @@ h1.example-title .text {
       padding-left: 1.5rem;
       padding-right: 1.5rem;
     }
+  }
+}
+
+// Equations
+// --------------------------------------------------
+.equation,
+[data-type="equation"] {
+  position: relative;
+
+  .os-equation-number {
+    font-weight: bold;
+    position: absolute;
+    right: 0;
+    top: 50%;
+    transform: translate3d(0, -50%, 0);
   }
 }
 

--- a/src/scripts/modules/media/body/content-baked.less
+++ b/src/scripts/modules/media/body/content-baked.less
@@ -251,10 +251,6 @@ h1.example-title .text {
 }
 .os-eoc [data-type="exercise"],
 .os-eoc .exercise {
-  span {
-    font-weight: bold;
-    padding-right: 0.5rem
-  }
   p { display: inline; }
   [data-type="problem"] > .number {
     .exercise-number();

--- a/src/scripts/modules/media/body/content-common.less
+++ b/src/scripts/modules/media/body/content-common.less
@@ -526,62 +526,6 @@ div[data-type='list'][data-list-type]             { padding-left: 2.5rem; margin
 
 }
 
-// Skeleton for constructing the blockish elements
-// This contains all the selectors for the styling
-
-// Helper mixin for expanding all the selectors
-.make-block(@type) {
-  #blockish>.style(@type);
-
-  // There are 3 cases for a label:
-  // - none   : The attribute is not on the element so show the default label
-  // - empty  : The attribute is present and it is the empty string; the default label should be suppressed
-  // - custom : The attribute contains a custom string that should be displayed instead of the default label
-
-  // Puts in the text of the label. Depending on if there is a title
-  // it will be added either as a `:before` on the blockish element or on the title element
-  .format-label(@type; @label-type; @has-title) { }
-  .format-label(@type; none;        false) { #blockish>.default-label(@type; false); }
-  .format-label(@type; empty;       false) { } // Nothing will show up
-  .format-label(@type; custom;      false) { content: attr(data-label); }
-  .format-label(@type; none;        true)  { #blockish>.default-label(@type; true); }
-  .format-label(@type; empty;       true)  { } // Only the title will show up
-  .format-label(@type; custom;      true)  { content: attr(data-label-parent) ': '; }
-
-  // Add the label to the title element (if one exists) or to the blockish element
-  .place-label(@type; @label-type) {
-    // A title exists so style it and put the label in `.title::before`
-    // FIXME: Remove the following line.
-    // Aloha and webview have slightly different places for the title
-    &.ui-has-child-title > header > [data-type="title"],
-    &.ui-has-child-title > [data-type="title"],
-    &.ui-has-child-title > header > .title,
-    &.ui-has-child-title > .title {
-      #blockish>.title(@type);
-      &::before { .format-label(@type; @label-type; true); }
-    }
-    // // No title exists so style the blockish::before and put the label there
-    // &:not(.ui-has-child-title)::before {
-    //   #blockish>.title(@type);
-    //   .format-label(@type; @label-type; false);
-    // }
-  }
-
-  // Decide which case of the label we are dealing with
-  &:not([data-label])                 { .place-label(@type; none); }
-  &[data-label='']                    { .place-label(@type; empty); }
-  &[data-label]:not([data-label=''])  { .place-label(@type; custom); }
-
-  // Style the Body
-  > section         { #blockish>.body(@type); }
-}
-
-
-[data-type="note"],
-.note     { .make-block(note); }
-[data-type="example"],
-.example  { .make-block(example); }
-
 
 .mixin-exercise() {
   [data-type="problem"],

--- a/src/scripts/modules/media/body/content-raw.less
+++ b/src/scripts/modules/media/body/content-raw.less
@@ -3,6 +3,8 @@
 //
 //     #content { @import 'this_file.less'; }
 
+@import '_make-block';
+
 h1,
 h2,
 h3,
@@ -89,6 +91,10 @@ figure:not([data-orient="vertical"]) {
 
 }
 
+[data-type="note"],
+.note     { .make-block(note); }
+[data-type="example"],
+.example  { .make-block(example); }
 
 [data-type="exercise"],
 .exercise { .make-block(exercise); }

--- a/src/scripts/modules/media/body/content.less
+++ b/src/scripts/modules/media/body/content.less
@@ -3,12 +3,12 @@
 //
 //     #content { @import 'this_file.less'; }
 
-@import './content-common';
+@import 'content-common';
 
 &[data-is-baked="false"] {
-  @import 'content-raw.less';
+  @import 'content-raw';
 }
 
 &[data-is-baked="true"] {
-  @import 'content-baked.less';
+  @import 'content-baked';
 }

--- a/src/scripts/modules/media/header/header.less
+++ b/src/scripts/modules/media/header/header.less
@@ -30,6 +30,10 @@
       padding-right: 0.4em;
     }
 
+    .os-number {
+      font-weight: 500;
+    }
+
     // When editing is turned on the Title becomes an input box; make sure it stretches
     input[type="text"] {
       width: 55rem;

--- a/src/scripts/modules/media/tabs/contents/toc/section.less
+++ b/src/scripts/modules/media/tabs/contents/toc/section.less
@@ -47,6 +47,10 @@
           vertical-align: middle;
           cursor: pointer;
 
+          .os-number {
+            font-weight: bold;
+          }
+
           small {
             margin-left: 1rem;
             color: red;

--- a/src/scripts/pages/donate/form/form-template.html
+++ b/src/scripts/pages/donate/form/form-template.html
@@ -15,7 +15,7 @@
     <input type="hidden" name="UPAY_SITE_ID" id="UPAY_SITE_ID" value="8" />
     <input type="hidden" name="Revenue_amount" id="Revenue_amount" value="0" />
     <input type="hidden" name="Donation_To" id="Donation_To" value="OpenStax CNX" />
-    <input type="hidden" name="TNE_Admin_Email" value="openstaxgiving@rice.edu" />
+    <input type="hidden" name="TNE_Admin_Email" value="{{donation}}" />
     <input type="hidden" name="Rice_Relate" id="Rice_Relation" value="Friend" />
     <input type="hidden" name="TNE_Customer_From" value="cnx@cnx.org" />
     <input type="hidden" name="TNE_Customer_Subject" value="OpenStax CNX Donation Receipt" />

--- a/src/scripts/pages/donate/form/form.coffee
+++ b/src/scripts/pages/donate/form/form.coffee
@@ -3,6 +3,7 @@ define (require) ->
   validationHelper = require('cs!helpers/validation')
   BaseView = require('cs!helpers/backbone/views/base')
   template = require('hbs!./form-template')
+  settings = require('settings')
   require('less!./form')
 
   countries = [
@@ -345,6 +346,8 @@ define (require) ->
         url = "#{location.protocol}//#{location.host}/donate"
         url += "/download/#{@uuid}/#{@type}" if @uuid and @type
         return url
+      donation: () ->
+        return settings.donation
 
     events:
       'submit form': 'onSubmit'

--- a/src/scripts/settings.js
+++ b/src/scripts/settings.js
@@ -38,6 +38,9 @@
       // Webmaster E-mail address
       webmaster: 'support@openstax.org',
 
+      // Donate E-mail address
+      donation: 'openstaxgiving@rice.edu',
+
       // Content shortcodes
       shortcodes: {
         'college-physics': '031da8d3-b525-429c-80cf-6c8ed997733a@8.1',


### PR DESCRIPTION
## Problem description
 if a user follows an inter-book link in baked content (i.e. Review Questions to Answer Key), the URL being navigated away from is not stored in browser history, yet two extra entries are stored in history, one being the long href with a hash (i.e. `#fs-id2197874-solution`), and one without a hash. Finally, the URL is canonicalized and updated, and stored in history. 

Example URL: 
```
/contents/185cbf87-c72e-48f5-b51e-f14f21b5eabd@10.61:a2d22c3d-7bba-5629-bb1a-a2e5eb375e0f@10.61#fs-id2197874-solution
```

## Expected behavior
User follows link, origin URL is stored, two intermediate URLs are not stored, final URL is stored. 

## Bottom line for my changes
Back button now works reliably, but still stores extra URLs in the history. ~~Navbar hiding anchors is fixed.~~

## What I need help with :)

This problem ended up being decently complicated. Backbone's `navigate` is extended in `history.coffee` such that it removes the regular functionality of `navigate`: normally, when `{trigger: true, replace: true}` is passed in to `navigate`, the route is triggered but the URL is **not** updated, [as seen in the docs](http://backbonejs.org/#Router-navigate). However, from `history.coffee`:
```
@history[if options.replace then 'replaceState' else 'pushState']({}, document.title, url)
```
As far as I know, this is equivalent to `history.replaceState()` which actually replaces the most recent entry in the browser history with a given URL. An erroneous call to this was replacing the URL being navigated away from (one part of the problem).

That's fine - what sucks is, I need _exactly_ what the functionality was before (so we can navigate to a route without updating the URL). I don't want to change the way `navigate` is extended because I'm afraid it will break all the other usages in the application. However, I think that's what will have to happen. **_Does anyone have any input on this?_**

Right now, the back button functionality is fixed in that it is usable (the user can actually get back to the original page), but you still must click back 3 times to get to the page you clicked the link on. 

Interestingly, if [these lines](https://github.com/Connexions/webview/blob/0c7b32b9da36c89d57c0854348457d9226c68ff7/src/scripts/modules/media/body/body.coffee#L449-L451) which handle jumping to a hash are removed, the two "long" URLs are **not** cached in browser history. Of course, this breaks jumping to hashes.  **_Any ideas about that?_**

~~Sorry for wall of text, but one more thing - I added a one-line change at [line 455](https://github.com/Connexions/webview/blob/0c7b32b9da36c89d57c0854348457d9226c68ff7/src/scripts/modules/media/body/body.coffee#L455) which scrolls up by the height of the navbar, so anchors aren't covered.~~ 