### PR TITLE
update coach version to include exercises fix for the latest tutor api

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -25,7 +25,7 @@
     "select2": "4.0.3",
     "babel-polyfill": "0.0.1",
     "l20n": "https://github.com/katalysteducation/l20n.js.git#v4.0.15",
-    "concept-coach": "openstax/tutor-js#coach-20170308.c",
+    "concept-coach": "openstax/tutor-js#coach-20170630.a",
     "custom-event-polyfill": "0.3.0"
   },
   "devDependencies": {


### PR DESCRIPTION
updates coach to [coach-20170630.a](https://github.com/openstax/tutor-js/releases/tag/coach-20170630.a)