### PR TITLE
Fix scripts to get the nvm settings from script/bootstrap

### DIFF
--- a/script/build
+++ b/script/build
@@ -1,4 +1,6 @@
 #!/bin/bash
 
+source ./script/bootstrap || exit 1
+
 >&2 echo "==> Building dist/"
 npm run-script dist || exit 1

--- a/script/setup
+++ b/script/setup
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-./script/bootstrap || exit 1
+source ./script/bootstrap || exit 1
 
 >&2 echo "==> Installing package dependencies"
 npm install || exit 1


### PR DESCRIPTION
script/bootstrap has `source ~/.nvm/nvm.sh` which sets up the $PATH
environment variable.  That is how `npm` and `node` can be found.  This
works in script/bootstrap, but when it gets back to script/setup, $PATH
is not set up anymore and it cannot find `npm`.

On jenkins, we are seeing:

```
17:57:24 Now using node v6.9.1 (npm v3.10.8)
17:57:24 Using node: v6.9.1
17:57:25 Using npm: 3.10.8
17:57:25 ==> Installing package dependencies
17:57:25 ./script/setup: line 6: npm: command not found
```

---

Jenkins built successfully: https://jenkins.cnx.org:8080/job/Build_CNX_webview/255/ :tada: