### PR TITLE
Don't use page number in links to other versions of book

### DIFF
--- a/src/scripts/helpers/links.coffee
+++ b/src/scripts/helpers/links.coffee
@@ -59,7 +59,7 @@ define (require) ->
 
       if model.isBook?()
         title = trim(model.get('currentPage')?.get('title'))
-        page = ":#{model.getPageNumber()}"
+        page = ":#{model.get('currentPage')?.getShortUuid()}"
 
       return "#{settings.root}contents/#{id}#{page}/#{title}"
 


### PR DESCRIPTION
The 'this isn't the latest version click here" message uses an old url composed of bookid and page number. That doesn't survive crossing book versions w/ different numbers of pages (before the page in question). We're hitting this old bug more now, because going from unbaked -> baked will reliably add one or more pages to every single chapter.