### PR TITLE
add support for analytics array

### DIFF
--- a/src/scripts/helpers/handlers/analytics.coffee
+++ b/src/scripts/helpers/handlers/analytics.coffee
@@ -14,18 +14,25 @@ define (require) ->
         l: Date.now()
 
     # Send the current page to every analytics service
-    send: (account, fragment = Backbone.history.fragment) ->
-      if not /^\//.test(fragment) then fragment = '/' + fragment
+    sendAnalytics: (accounts, fragment = Backbone.history.fragment) ->
+
+      # temporarily support a single field for analytics (sometimes it is `null`)
+      unless Array.isArray(accounts)
+        console.log 'Consider calling analytics.sendAnalytics with an Array'
+        @sendAnalytics([accounts], fragment)
 
       require ['analytics'], (ga) =>
-        # Use the default analytics ID in settings if no account is specified
-        account ?= settings.analyticsID
 
-        # TODO investigate if we need specific names for our tracker name
-        trackerName = @getTrackerName(account)
-        ga('create', account, 'auto', trackerName)
+        accounts.forEach (account) =>
+          if not /^\//.test(fragment) then fragment = '/' + fragment
+          # Use the default analytics ID in settings if no account is specified
+          account ?= settings.analyticsID
 
-        ga("#{trackerName}.send", 'pageview', fragment)
+          # TODO investigate if we need specific names for our tracker name
+          trackerName = @getTrackerName(account)
+          ga('create', account, 'auto', trackerName)
+
+          ga("#{trackerName}.send", 'pageview', fragment)
 
     getTrackerName: (account) ->
       # Strip non-alphanumeric characters for default trackerName

--- a/src/scripts/loader.coffee
+++ b/src/scripts/loader.coffee
@@ -91,7 +91,7 @@ define (require) ->
     if location.search
       router.navigate(Backbone.history.fragment, {replace: true})
 
-    analytics.send() # Track analytics for the initial page
+    analytics.sendAnalytics() # Track analytics for the initial page
 
     # Prefix all non-external AJAX requests with the root URI
     $.ajaxPrefilter (options, originalOptions, jqXHR) ->

--- a/src/scripts/modules/media/media.coffee
+++ b/src/scripts/modules/media/media.coffee
@@ -1,5 +1,6 @@
 define (require) ->
   $ = require('jquery')
+  Backbone = require('backbone')
   linksHelper = require('cs!helpers/links')
   router = require('cs!router')
   analytics = require('cs!helpers/handlers/analytics')
@@ -202,8 +203,8 @@ define (require) ->
 
     trackAnalytics: () ->
       # Track loading using the media's own analytics ID, if specified
-      analyticsID = @model.get('googleAnalytics')
-      analytics.send(analyticsID) if analyticsID
+      analyticsIDs = @model.get('googleAnalytics')
+      analytics.sendAnalytics(analyticsIDs) if analyticsIDs
 
     updatePageInfo: () ->
       @pageTitle = @model.get('title')
@@ -247,4 +248,3 @@ define (require) ->
 
     resetKeySequence: (e) ->
       return
-

--- a/src/scripts/modules/media/tabs/contents/toc/page.coffee
+++ b/src/scripts/modules/media/tabs/contents/toc/page.coffee
@@ -58,7 +58,7 @@ define (require) ->
 
     trackNav: () ->
       tree = @collection.get('book') or @collection
-      analyticsID = tree.get('googleAnalytics')
-      analytics.send(analyticsID) if analyticsID
+      analyticsIDs = tree.get('googleAnalytics')
+      analytics.sendAnalytics(analyticsIDs) if analyticsIDs
 
     removeNode: () -> @content.removeNode(@model)

--- a/src/scripts/router.coffee
+++ b/src/scripts/router.coffee
@@ -54,6 +54,6 @@ define (require) ->
 
     navigate: (fragment, options = {}, cb) ->
       super(arguments...)
-      analytics.send() if options.analytics isnt false
+      analytics.sendAnalytics() if options.analytics isnt false
       cb?()
       @trigger('navigate')


### PR DESCRIPTION
This changes the analytics code to support an array of analytics IDs rather than a single analytics ID.

The various call sites may be good candidates for cleaning up when exactly we send an analytics event.

# Notes

One thing that might be worth including soon (maybe in a subsequent PR) is to fix when these analytics events are being fired. It might be worth spending time to write unit tests so they don't break in the future.