### PR TITLE
update canonical link for each page

### DIFF
--- a/src/scripts/helpers/links.coffee
+++ b/src/scripts/helpers/links.coffee
@@ -51,7 +51,7 @@ define (require) ->
       return url
 
     # Get the URL to view a given content model
-    getModelPath: (model, withTitle = true) ->
+    getModelPath: (model, withTitle) ->
       page = ''
       id = model.getUuid?() or model.id
       version = model.get?('version') or model.version

--- a/src/scripts/helpers/links.coffee
+++ b/src/scripts/helpers/links.coffee
@@ -51,7 +51,7 @@ define (require) ->
       return url
 
     # Get the URL to view a given content model
-    getModelPath: (model) ->
+    getModelPath: (model, withTitle = true) ->
       page = ''
       id = model.getUuid?() or model.id
       version = model.get?('version') or model.version
@@ -59,9 +59,12 @@ define (require) ->
 
       if model.isBook?()
         title = trim(model.get('currentPage')?.get('title'))
-        page = ":#{model.get('currentPage')?.getShortUuid()}"
+        page = ":#{model.get('currentPage')?.getUuid()}"
 
-      return "#{settings.root}contents/#{id}#{page}/#{title}"
+      url = "#{settings.root}contents/#{id}#{page}"
+      url += "/#{title}" if withTitle
+
+      return url
 
     getCleanSearchQuery: (queryString, paramsToIgnore) ->
       queryString ?= window.location.search

--- a/src/scripts/modules/media/footer/metadata/metadata.coffee
+++ b/src/scripts/modules/media/footer/metadata/metadata.coffee
@@ -23,7 +23,7 @@ define (require) ->
       model.languages = settings.languages
       model.languageName = settings.languages[model.language]
       model.subjectsList = subjects.list
-      model.url = linksHelper.getModelPath(model)
+      model.url = linksHelper.getModelPath(model, true)
       model.printStyles =
         {
           'default' : 'Default',

--- a/src/scripts/modules/media/latest/latest.coffee
+++ b/src/scripts/modules/media/latest/latest.coffee
@@ -9,7 +9,7 @@ define (require) ->
     template: template
     templateHelpers:
       url: () ->
-        path = linksHelper.getModelPath(@model)
+        path = linksHelper.getModelPath(@model, true)
         queryString = linksHelper.serializeQuery(location.search)
         if queryString.minimal then return path + '?minimal=true' else return path
 

--- a/src/scripts/modules/media/media.coffee
+++ b/src/scripts/modules/media/media.coffee
@@ -24,11 +24,7 @@ define (require) ->
   return class MediaView extends BaseView
     key = []
     canonical: () ->
-      uuid = @model.getUuid()
-      if uuid
-        return "//#{location.host}/contents/#{uuid}/"
-      else
-        return null
+      return linksHelper.getModelPath(@model, false)
 
     template: template
     regions:


### PR DESCRIPTION
This will now correctly set the `<link rel="canonical">` header to the value of the book uuid + page uuid, without versions, rather than just the book uuid for all pages. This is needed stop confusing Google and hypothes.is as to the correct URL to use for a given page.