### PR TITLE
do not redirect when unicode characters are in the URL

### DIFF
--- a/src/scripts/router.coffee
+++ b/src/scripts/router.coffee
@@ -8,9 +8,9 @@ define (require) ->
 
   return new class Router extends Backbone.Router
     initialize: (args...) ->
-      decodedPathname = decodeURIComponent(window.location.pathname)
-      if (decodedPathname != window.location.pathname)
-        window.location.replace(decodeURIComponent(window.location))
+      # decodedPathname = decodeURIComponent(window.location.pathname)
+      # if (decodedPathname != window.location.pathname)
+      #   window.location.replace(decodeURIComponent(window.location))
       @appView = new AppView()
 
       # Default Route


### PR DESCRIPTION
When a URL contains unicode characters, the page just constantly reloads. This code was originally added in #1319 to handle `@` and `:` but it might no longer be necessary