### PR TITLE
Mockup toc leftovers

### DIFF
--- a/src/scripts/modules/media/tabs/contents/contents-template.html
+++ b/src/scripts/modules/media/tabs/contents/contents-template.html
@@ -43,7 +43,7 @@
             </li>
             <li>
               <div>
-                  <a data-l10n-id="textbook-view-book-list-go-to-book" href="/contents/{{shortid}}" data-page="2" data-trigger="false">
+                  <a data-l10n-id="textbook-view-book-list-go-to-book" href="/contents/{{shortid}}">
                     Go to Book
                   </a>
               </div>

--- a/src/scripts/router.coffee
+++ b/src/scripts/router.coffee
@@ -8,9 +8,6 @@ define (require) ->
 
   return new class Router extends Backbone.Router
     initialize: (args...) ->
-      # decodedPathname = decodeURIComponent(window.location.pathname)
-      # if (decodedPathname != window.location.pathname)
-      #   window.location.replace(decodeURIComponent(window.location))
       @appView = new AppView()
 
       # Default Route


### PR DESCRIPTION
A couple attributes left over from the book list roots as a TOC mockup.

In particular data-trigger="false" kept the click from reloading the page.

Fixes #1614 