### PR TITLE
remove the max-two-lines for Books that a Page is in

### DIFF
--- a/src/scripts/modules/media/tabs/contents/contents-template.html
+++ b/src/scripts/modules/media/tabs/contents/contents-template.html
@@ -24,8 +24,8 @@
       <br>
       <ul>
         {{#each booksIn}}
-        <li >
-            <div class="max-wrap-two-lines">
+        <li>
+            <div>
                 <a href="/contents/{{shortid}}:{{../pageId}}">
                   <b>{{title}}</b>
                 </a>

--- a/src/scripts/modules/media/tabs/contents/contents.less
+++ b/src/scripts/modules/media/tabs/contents/contents.less
@@ -22,13 +22,6 @@
     border-bottom: solid 1px @gray-lightest;
   }
 
-  .max-wrap-two-lines {
-    overflow: hidden;
-    display: -webkit-box;
-    -webkit-line-clamp: 2;
-    -webkit-box-orient: vertical;
-  }
-
   > .add {
     margin: 0.5rem 0 0.5rem @left-menu-indent;
   }


### PR DESCRIPTION
for listing Books that a Page is in. This was introduced in #1606 but only worked for some browsers, and caused rendering problems in MS Edge (see #1610)