### PR TITLE
Mobile scrolling

### DIFF
--- a/src/scripts/modules/media/media.coffee
+++ b/src/scripts/modules/media/media.coffee
@@ -129,6 +129,7 @@ define (require) ->
         isPinned = true
         adjustMainMargin($pinnable.height())
       unpinNavBar = ->
+        $pinnable.removeClass('opened')
         $pinnable.removeClass('pinned')
         $titleArea.removeClass('compact')
         $toc.removeClass('pinned')
@@ -139,26 +140,38 @@ define (require) ->
         $titleArea = mediaTitleView.$el.find('.media-title')
         $titleArea.addClass('compact') if isPinned
       )
+      pinNavBarSlow = ->
+        $pinnable.removeClass('closed')
+        $pinnable.addClass('opened')
+      unpinNavBarSlow = ->
+        $pinnable.addClass('pinned')
+        $toc.addClass('pinned')
+        $pinnable.removeClass('opened')
+        $pinnable.addClass('closed')
+        adjustMainMargin(0)
+        isPinned = false
+        pinnableTop = $pinnable.offset().top
+
 
       handleHeaderViewPinning = ->
         top = $(window).scrollTop()
 
-        if top < @scrollPosition && window.innerWidth < 640
-          # scrolling up want to make the header reappear
-          pinNavBar()
-        else if (top > @scrollPosition && window.innerWidth < 640) && !navView.tocIsOpen
-          # scrolling down want to make the header dissapear
+        if top <= pinnableTop
           unpinNavBar()
-
-        if top > pinnableTop
-          if not isPinned
-            if navView.tocIsOpen && window.innerWidth < 640
-              pinNavBar()
-            else
-              if window.innerWidth >= 640
+        else
+          if window.innerWidth < 640
+            if top + 20 < @scrollPosition && window.innerWidth < 640
+              # scrolling up want to make the header reappear
+              if not isPinned
                 pinNavBar()
-        else if isPinned
-          unpinNavBar()
+                pinNavBarSlow()
+            else if (top > @scrollPosition && window.innerWidth < 640) && !navView.tocIsOpen
+              # scrolling down want to make the header dissapear
+              if isPinned
+                unpinNavBarSlow()
+          else if not isPinned
+            pinNavBar()
+
         setTocHeight()
 
         @scrollPosition = top

--- a/src/scripts/modules/media/media.coffee
+++ b/src/scripts/modules/media/media.coffee
@@ -160,7 +160,7 @@ define (require) ->
           unpinNavBar()
         else
           if window.innerWidth < 640
-            if top + 20 < @scrollPosition && window.innerWidth < 640
+            if top + 30 < @scrollPosition && window.innerWidth < 640
               # scrolling up want to make the header reappear
               if not isPinned
                 pinNavBar()

--- a/src/scripts/modules/media/media.coffee
+++ b/src/scripts/modules/media/media.coffee
@@ -23,6 +23,7 @@ define (require) ->
   require('less!./media')
 
   return class MediaView extends BaseView
+    scrollPosition: 0
     key = []
     canonical: () ->
       return linksHelper.getModelPath(@model, false)
@@ -122,11 +123,12 @@ define (require) ->
 
       $titleArea = mediaTitleView.$el.find('.media-title')
       pinNavBar = ->
-        $pinnable.addClass('pinned')
-        $titleArea.addClass('compact')
-        $toc.addClass('pinned')
-        isPinned = true
-        adjustMainMargin($pinnable.height())
+        if window.innerWidth > 640
+          $pinnable.addClass('pinned')
+          $titleArea.addClass('compact')
+          $toc.addClass('pinned')
+          isPinned = true
+          adjustMainMargin($pinnable.height())
       unpinNavBar = ->
         $pinnable.removeClass('pinned')
         $titleArea.removeClass('compact')
@@ -141,12 +143,23 @@ define (require) ->
 
       handleHeaderViewPinning = ->
         top = $(window).scrollTop()
+
+        if top < @scrollPosition && window.innerWidth < 640
+          # scrolling up want to make the header reappear
+          $pinnable.addClass('pinned')
+          $titleArea.addClass('compact')
+          $toc.addClass('pinned')
+          isPinned = true
+          adjustMainMargin($pinnable.height())
+
         if top > pinnableTop
           if not isPinned
             pinNavBar()
         else if isPinned
           unpinNavBar()
         setTocHeight()
+
+        @scrollPosition = top
       Backbone.on('window:optimizedScroll', handleHeaderViewPinning)
       # closing is triggered in 'onBeforeClose'
       @on('closing', ->

--- a/src/scripts/modules/media/media.less
+++ b/src/scripts/modules/media/media.less
@@ -11,7 +11,7 @@
     width: 100%;
     max-width: @max-viewport-width;
     z-index: 1;
-    transition: top 1s ease-in-out;
+    transition: top 0.4s ease-in-out;
   }
 
   .pinnable.closed{

--- a/src/scripts/modules/media/media.less
+++ b/src/scripts/modules/media/media.less
@@ -5,12 +5,23 @@
   height: 100%;
 
   .pinnable.pinned {
+    opacity: 1;
     position: fixed;
     top: 0;
     width: 100%;
     max-width: @max-viewport-width;
     z-index: 1;
+    transition: top 1s ease-in-out;
   }
+
+  .pinnable.closed{
+    top: -200px;
+  }
+
+  .pinnable.opened{
+    top: 0;
+  }
+
   .table-of-contents{
     overflow-y: auto;
     overflow-x: hidden;

--- a/src/scripts/modules/media/title/title.less
+++ b/src/scripts/modules/media/title/title.less
@@ -4,7 +4,7 @@
 .media-title {
   padding: 1rem 3rem;
   &.compact {
-    padding: 1rem 3rem 0 3rem;
+    padding: 1rem 1rem 0 1.3rem;
     font-size: 85%;
     .large-header {
       font-size: 1.8rem;
@@ -27,7 +27,6 @@
 
   > .title {
     overflow-wrap: break-word;
-	min-height: 60px;
 
     @media (min-width: @screen-sm-min) {
       display: inline-block;


### PR DESCRIPTION
changing mobile scrolling so that when scrolling down the entire header goes away, and then when scrolling back up the nav bar (contents button and title) comes back but you still have to scroll all the way to the top for the full header. Unless the toc is open then the nav bar and toc remain pinned Regular view remains unchanged