### PR TITLE
Do not strip non-ascii chars from url

### DIFF
--- a/src/scripts/helpers/handlebars/trim.coffee
+++ b/src/scripts/helpers/handlebars/trim.coffee
@@ -5,7 +5,12 @@ define (require) ->
     temp = document.createElement("div")
     temp.innerHTML = str
     str = temp.textContent
-    str.replace(/[\u2000-\u206F\u2E00-\u2E7F\\'!"#$%&()*+,\-.\/:;<=>?@\[\]^_`{|}~\s+]/g, '-')
+    # replace symbols with whitespace
+    str = str.replace(/[\u2000-\u206F\u2E00-\u2E7F\\'!"#$%&()*+,\-.\/:;<=>?@\[\]^_`{|}~\s+]/g, ' ')
+    # remove leading and trailing whitespace
+    str = str.replace(/^\s+|\s+$/g, '')
+    # replace spaces with dashes
+    str = str.replace(/\s+/g, '-')
 
   Handlebars.registerHelper 'trim', (str) -> trim(str)
 

--- a/src/scripts/helpers/handlebars/trim.coffee
+++ b/src/scripts/helpers/handlebars/trim.coffee
@@ -5,7 +5,7 @@ define (require) ->
     temp = document.createElement("div")
     temp.innerHTML = str
     str = temp.textContent
-    str.replace(/\s/g, '-').replace(/[^a-zA-Z0-9 -]/g, '').substring(0, 30)
+    str.replace(/[^\w\s)]/g, '').replace(/\s/g, '-')
 
   Handlebars.registerHelper 'trim', (str) -> trim(str)
 

--- a/src/scripts/helpers/handlebars/trim.coffee
+++ b/src/scripts/helpers/handlebars/trim.coffee
@@ -5,7 +5,7 @@ define (require) ->
     temp = document.createElement("div")
     temp.innerHTML = str
     str = temp.textContent
-    str.replace(/[^\w\s)]/g, '').replace(/\s/g, '-')
+    str.replace(/[^\w\s]/g, '').replace(/\s/g, '-')
 
   Handlebars.registerHelper 'trim', (str) -> trim(str)
 

--- a/src/scripts/helpers/handlebars/trim.coffee
+++ b/src/scripts/helpers/handlebars/trim.coffee
@@ -5,7 +5,7 @@ define (require) ->
     temp = document.createElement("div")
     temp.innerHTML = str
     str = temp.textContent
-    str.replace(/[\u2000-\u206F\u2E00-\u2E7F\\'!"#$%&()*+,\-.\/:;<=>?@\[\]^_`{|}~]/g, '').replace(/\s/g, '-')
+    str.replace(/[\u2000-\u206F\u2E00-\u2E7F\\'!"#$%&()*+,\-.\/:;<=>?@\[\]^_`{|}~\s+]/g, '-')
 
   Handlebars.registerHelper 'trim', (str) -> trim(str)
 

--- a/src/scripts/helpers/handlebars/trim.coffee
+++ b/src/scripts/helpers/handlebars/trim.coffee
@@ -5,7 +5,7 @@ define (require) ->
     temp = document.createElement("div")
     temp.innerHTML = str
     str = temp.textContent
-    str.replace(/[^\w\s]/g, '').replace(/\s/g, '-')
+    str.replace(/[\u2000-\u206F\u2E00-\u2E7F\\'!"#$%&()*+,\-.\/:;<=>?@\[\]^_`{|}~]/g, '').replace(/\s/g, '-')
 
   Handlebars.registerHelper 'trim', (str) -> trim(str)
 

--- a/test/scripts/helpers/handlebars/trim.js
+++ b/test/scripts/helpers/handlebars/trim.js
@@ -11,11 +11,6 @@ describe('handlebars trim helper tests', function () {
     });
   });
 
-  it('should cut the string down to 30 characters', function () {
-    var returnVal = Handlebars.helpers.trim('thisisastringwiththirtysixcharacters');
-    returnVal.length.should.equal(30);
-    returnVal.should.equal('thisisastringwiththirtysixchar');
-  });
   it('should replace white space with dashes', function () {
     // space
     Handlebars.helpers.trim('  lots of    spaces ').should.equal('--lots-of----spaces-');

--- a/test/scripts/helpers/handlebars/trim.js
+++ b/test/scripts/helpers/handlebars/trim.js
@@ -11,6 +11,10 @@ describe('handlebars trim helper tests', function () {
     });
   });
 
+  it('should leave special characters alone and replace spaces', function() {
+    Handlebars.helpers.trim('Najważniejsze stałe fizyczne').should.equal('najważniejsze-stałe-fizyczne');
+  });
+
   it('should replace white space with dashes', function () {
     // space
     Handlebars.helpers.trim('  lots of    spaces ').should.equal('--lots-of----spaces-');

--- a/test/scripts/helpers/handlebars/trim.js
+++ b/test/scripts/helpers/handlebars/trim.js
@@ -17,10 +17,10 @@ describe('handlebars trim helper tests', function () {
 
   it('should replace white space with dashes', function () {
     // space
-    Handlebars.helpers.trim('  lots of    spaces ').should.equal('--lots-of----spaces-');
+    Handlebars.helpers.trim('  lots of    spaces ').should.equal('lots-of-spaces');
     // tabs
-    Handlebars.helpers.trim('\tsome\ttabs\t').should.equal('-some-tabs-');
+    Handlebars.helpers.trim('\tsome\ttabs\t').should.equal('some-tabs');
     // new lines
-    Handlebars.helpers.trim('anewline\n').should.equal('anewline-');
+    Handlebars.helpers.trim('anewline\n').should.equal('anewline');
   });
 });

--- a/test/scripts/helpers/handlebars/trim.js
+++ b/test/scripts/helpers/handlebars/trim.js
@@ -12,7 +12,7 @@ describe('handlebars trim helper tests', function () {
   });
 
   it('should leave special characters alone and replace spaces', function () {
-    Handlebars.helpers.trim('Najważniejsze stałe fizyczne').should.equal('najważniejsze-stałe-fizyczne');
+    Handlebars.helpers.trim('Najważniejsze stałe fizyczne').should.equal('Najważniejsze-stałe-fizyczne');
   });
 
   it('should replace white space with dashes', function () {

--- a/test/scripts/helpers/handlebars/trim.js
+++ b/test/scripts/helpers/handlebars/trim.js
@@ -11,7 +11,7 @@ describe('handlebars trim helper tests', function () {
     });
   });
 
-  it('should leave special characters alone and replace spaces', function() {
+  it('should leave special characters alone and replace spaces', function () {
     Handlebars.helpers.trim('Najważniejsze stałe fizyczne').should.equal('najważniejsze-stałe-fizyczne');
   });
 

--- a/test/scripts/helpers/links.js
+++ b/test/scripts/helpers/links.js
@@ -102,7 +102,7 @@ describe('links helper tests', function () {
         },
         page: 'page'
       };
-      links.getPath(page, data).should.equal('/contents/book name@book name:page title!@page title!/page-title');
+      links.getPath(page, data).should.equal('/contents/book name@book name:page title!@page title!/page-title-');
     });
   });
   describe('serialize query tests', function () {

--- a/test/scripts/helpers/links.js
+++ b/test/scripts/helpers/links.js
@@ -102,7 +102,7 @@ describe('links helper tests', function () {
         },
         page: 'page'
       };
-      links.getPath(page, data).should.equal('/contents/book name@book name:page title!@page title!/page-title-');
+      links.getPath(page, data).should.equal('/contents/book name@book name:page title!@page title!/page-title');
     });
   });
   describe('serialize query tests', function () {


### PR DESCRIPTION
Test plan
=====
Story
-----
AAT, I'd like a webview test that asserts Unicode in URL is allowed

Steps
---
1. Visit:
https://qa.cnx.org/contents/TqqPA4io@1.1:tjWnLaNJ@2 
it redirects to:
https://qa.cnx.org/contents/TqqPA4io@1.1:tjWnLaNJ@2/123-Naprężenie-odkształcenie-i-moduł-sprężystości 
instead of:
https://qa.cnx.org/contents/TqqPA4io@1.1:tjWnLaNJ@2/123-Naprenie-odksztacenie-i-mo
2. Ie.: if the Unicode characters in the URL become stripped out (from the page title), this is a bug.

Expected result
----
- A URL with Unicode characters shows up complete in the address bar.
- Whitespace is replaced with dashes.
- Punctuation is stripped out (ie. question marks, exclamation marks)