### PR TITLE
Upgrade MathJax to 2.7.4 and enable SRE for accessibility

### DIFF
--- a/src/scripts/config.js
+++ b/src/scripts/config.js
@@ -21,7 +21,7 @@
       'backbone-associations': '../../bower_components/backbone-associations/backbone-associations',
 
       // ## MathJax
-      mathjax: '//cdnjs.cloudflare.com/ajax/libs/mathjax/2.6.1/MathJax.js?config=MML_HTMLorMML',
+      mathjax: '//cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.4/MathJax.js?config=MML_HTMLorMML',
 
       // Use Minified Aloha because loading files in a different requirejs context is a royal pain
       aloha: '../../bower_components/aloha-editor/target/build-profile-with-oer/rjs-output/lib/aloha',
@@ -110,7 +110,8 @@
               'tex2jax.js',
               'mml2jax.js',
               'MathMenu.js',
-              'MathZoom.js'
+              'MathZoom.js',
+              '[a11y]/mathjax-sre.js',
             ],
             tex2jax: {
               inlineMath: [


### PR DESCRIPTION
Upgrade MathJax to 2.7.4 and enable SRE for accessibility. MathJax was upgraded because the MathJax SRE extension doesn't exist for MathJax 2.6.1.

The [AssistiveMML](https://docs.mathjax.org/en/latest/options/extensions/assistive-mml.html) just exposes MathML to browsers that support reading it... it does not add human-readable alt-text... the [mathjax-sre.js](https://github.com/mathjax/MathJax-a11y/blob/master/docs/README.md#introduction) does that (adds human-readable text).

In order to include `mathjax-sre.js` we had to upgrade MathJax to 2.7