### PR TITLE
send canonical URL to book analytics

### DIFF
--- a/src/scripts/models/content.coffee
+++ b/src/scripts/models/content.coffee
@@ -5,6 +5,7 @@ define (require) ->
   settings = require('settings')
   Collection = require('cs!models/contents/collection')
   Page = require('cs!models/contents/page')
+  analytics = require('cs!helpers/handlers/analytics')
 
   return class Content extends Collection
     relations: [{
@@ -46,6 +47,15 @@ define (require) ->
 
         .fail (model, response, options) =>
           @set('error', response?.status or model?.status or 9000)
+
+      @on('change:canonicalPath', @sendPageViewAnalytics)
+
+    sendPageViewAnalytics: ->
+      # Track loading using the media's own analytics ID, if specified
+      analyticsIDs = @get('googleAnalytics')
+      analytics.sendAnalytics(analyticsIDs) if analyticsIDs
+      analytics.sendAnalytics() # Send site-wide analytics
+
 
     defaultPage: ->
       result = 1

--- a/src/scripts/modules/media/body/body.coffee
+++ b/src/scripts/modules/media/body/body.coffee
@@ -12,7 +12,6 @@ define (require) ->
   SimModal = require('cs!./embeddables/modals/sims/sims')
   template = require('hbs!./body-template')
   settings = require('settings')
-  analytics = require('cs!helpers/handlers/analytics')
   require('less!./body')
 
   embeddableTemplates =
@@ -71,7 +70,7 @@ define (require) ->
         # See #1601
         router.navigate(canonicalPath, {replace: true, analytics: false})
       # Only send analytics once the canonical URL is in the browser URL
-      analytics.sendAnalytics()
+      @model.set('canonicalPath', canonicalPath)
 
 
     updateTeacher: ($temp = @$el) ->

--- a/src/scripts/modules/media/media.coffee
+++ b/src/scripts/modules/media/media.coffee
@@ -49,7 +49,6 @@ define (require) ->
       @minimal = options.minimal
       @scrollPosition = 0
 
-      @listenTo(@model, 'change:googleAnalytics', @trackAnalytics)
       @listenTo(@model, 'change:title change:parent.id', @updatePageInfo)
       if not @minimal
         @listenTo(@model, 'change:legacy_id change:legacy_version change:currentPage
@@ -225,11 +224,6 @@ define (require) ->
       if title isnt components.title and not @model.isBook()
         router.navigate("contents/#{components.uuid}#{components.version}/\
         #{title}#{components.hash_path}#{qs}", {replace: true})
-
-    trackAnalytics: () ->
-      # Track loading using the media's own analytics ID, if specified
-      analyticsIDs = @model.get('googleAnalytics')
-      analytics.sendAnalytics(analyticsIDs) if analyticsIDs
 
     updatePageInfo: () ->
       @pageTitle = @model.get('title')

--- a/src/scripts/modules/media/nav/nav.coffee
+++ b/src/scripts/modules/media/nav/nav.coffee
@@ -114,10 +114,7 @@ define (require) ->
 
       e.preventDefault()
       e.stopPropagation()
-      href = $(e.currentTarget).attr('href')
-      # this sends the page without a version number (which causes analytics to fire).
-      # It fires twice because @mediaParent.trackAnalytics() also sends an event.
-      router.navigate href, {trigger: false}, () => @mediaParent.trackAnalytics()
+      # Rely on the Content.sendPageViewAnalytics to fire
 
     closeContentsOnSmallScreen: ->
       if window.innerWidth < 640


### PR DESCRIPTION
This defers sending Google Analytics until after the canonical URL is loaded into the browser.

The code assumes a couple of things:

- the browser URL is the canonical URL at the point when the `pageView` event is fired
- the `googleAnalytics` field is populated **before** the canonical URL is determined

# Screencap

(there is a persistent JSON parsing error in the screencap, but it's my machine, not a bug introduced in this code)

![google-analytics](https://user-images.githubusercontent.com/253202/41115919-eab67688-6a56-11e8-8d3c-86be2fb55e2d.gif)
