### PR TITLE
include page analytics tracker

### DIFF
--- a/src/scripts/modules/media/body/body.coffee
+++ b/src/scripts/modules/media/body/body.coffee
@@ -55,11 +55,17 @@ define (require) ->
       @listenTo(@model, 'change:currentPage.searchHtml', @render)
 
     canonicalizePath: =>
+      allTrackers = [settings.analyticsID]
+      if @model.get('googleAnalytics')
+        allTrackers = allTrackers.concat(@model.get('googleAnalytics'))
+
       if @model.isBook()
         currentPage = @model.get('currentPage')
         pageIsLoaded = currentPage?.get('loaded')
         return unless pageIsLoaded and currentPage.get('active')
         pageId = currentPage.getShortUuid()
+        if currentPage.get('googleAnalytics')
+          allTrackers = allTrackers.concat(currentPage.get('googleAnalytics'))
       else
         pageId = 0
       currentRoute = Backbone.history.getFragment()
@@ -71,8 +77,7 @@ define (require) ->
         # See #1601
         router.navigate(canonicalPath, {replace: true, analytics: false})
       # Only send analytics once the canonical URL is in the browser URL
-      allTrackers = [settings.analyticsID].concat(@model.get('googleAnalytics') or [])
-      analytics.sendAnalytics(allTrackers)
+      analytics.sendAnalytics(_.uniq(allTrackers))
 
 
     updateTeacher: ($temp = @$el) ->

--- a/src/scripts/modules/media/body/body.coffee
+++ b/src/scripts/modules/media/body/body.coffee
@@ -71,7 +71,8 @@ define (require) ->
         # See #1601
         router.navigate(canonicalPath, {replace: true, analytics: false})
       # Only send analytics once the canonical URL is in the browser URL
-      analytics.sendAnalytics()
+      allTrackers = [settings.analyticsID].concat(@model.get('googleAnalytics') or [])
+      analytics.sendAnalytics(allTrackers)
 
 
     updateTeacher: ($temp = @$el) ->


### PR DESCRIPTION
Originally reported in https://openstax.slack.com/archives/C196UGS2C/p1529053670000358

Trackers on just a Page were not being sent. This PR includes the page tracker as well when submitting analytics.

- Page in a book with both having trackers set (it looks like it might be the same tracker): `/contents/r-QzKsl_@7.23:_97x1rAv@2/Introduction-to-Sociology`
- Page in a book with just the page having a tracker `/contents/FqtblkWY@2.1:pLGsuj0f@2/Przedmowa`
- Just a Page with a tracker `/contents/pLGsuj0f@2/Przedmowa`
- Just a Page with no tracker: `/contents/KvFTO2EG@2/Acknowledgements`

Full testing probably needs to include a Book with no page tracker and maybe a case where the book and page trackers are different (but both set)

Full testing probably also needs to check that clicking Next/Prev will still send the tracking code

# Notes

Since we reverted https://github.com/Connexions/webview/pull/1656 this still sends duplicate pageviews (see screenshot)

# Screenshots


### Page in a book with a Page Tracker defined

`/contents/FqtblkWY@2.1:pLGsuj0f@2/Przedmowa`

![image](https://user-images.githubusercontent.com/253202/41480705-4734ffb4-709d-11e8-8148-10292d409c8b.png)

### Just a Page with a Tracker defined

`/contents/pLGsuj0f@2/Przedmowa`

![image](https://user-images.githubusercontent.com/253202/41481200-1b15caec-709f-11e8-808a-ea722e8250a7.png)


### Just a Page with no Tracker defined

`/contents/KvFTO2EG@2/Acknowledgements`

![image](https://user-images.githubusercontent.com/253202/41481040-83cf435c-709e-11e8-9471-4385fac5f414.png)

### Page in a book with a Book Tracker defined

`/contents/r-QzKsl_@7.23:_97x1rAv@2/Introduction-to-Sociology`

![image](https://user-images.githubusercontent.com/253202/41481111-c62f7fc8-709e-11e8-9263-332ee2c2aae4.png)
