### PR TITLE
fixed distance between QR codes and content

### DIFF
--- a/src/scripts/modules/media/body/content-baked.less
+++ b/src/scripts/modules/media/body/content-baked.less
@@ -154,7 +154,7 @@ figure:not([data-orient="vertical"]) {
     color: @gray;
   }
 
-  > span[data-type="media"] {
+  span[data-type="media"] {
     display: block;
     margin: 1rem 0;
   }


### PR DESCRIPTION
solving #1681 

I've changed general rule for `span` with `data-type="media"` inside blockish elements. I didn't find any place in Biology book that would be affected badly with this change (all I did was change the direct child into the child attribute, because some of the QR have more containers than others).