### PR TITLE
Fix improper text wrapping around exercise figures

### DIFF
--- a/src/scripts/modules/media/body/content-baked.less
+++ b/src/scripts/modules/media/body/content-baked.less
@@ -302,14 +302,9 @@ h1.example-title .text {
   }
 
   img {
-    float: left;
-    margin-right: 10px;
+    display: block;
+    padding-bottom: 1em;
   }
-
-  ol {
-    overflow: hidden;
-  }
-  clear: left;
 }
 
 .os-solutions-container {
@@ -335,4 +330,3 @@ h1.example-title .text {
 .appendix [data-type="list"] {
   margin-top: 1rem;
 }
-

--- a/src/scripts/modules/media/body/content-baked.less
+++ b/src/scripts/modules/media/body/content-baked.less
@@ -303,7 +303,7 @@ h1.example-title .text {
 
   img {
     display: block;
-    padding-bottom: 1em;
+    margin-bottom: 1em;
   }
 }
 


### PR DESCRIPTION
#1636 I've breaking the line after every image that appears in the exercise.
![image](https://user-images.githubusercontent.com/20907906/42631040-4778d09e-85d9-11e8-9132-f33add0ec012.png)

![image](https://user-images.githubusercontent.com/20907906/42631041-4930c25c-85d9-11e8-9707-cfdafcf50a42.png)
