### PR TITLE
Fix bugs found in the webview home page during testing

### DIFF
--- a/src/scripts/collections/featured-openstax-books.coffee
+++ b/src/scripts/collections/featured-openstax-books.coffee
@@ -18,7 +18,7 @@ define (require) ->
       _.each books, (book) ->
         book.cover = book.cover_url
         book.description = $(book.description).text()
-        book.link = "#{location.protocol}//#{location.host}/contents/#{book.cnx_id}"
+        book.link = "contents/#{book.cnx_id}"
         book.type = 'OpenStax Featured'
         book.id = book.id.toString()
 

--- a/src/scripts/modules/featured-books/featured-books-partial.html
+++ b/src/scripts/modules/featured-books/featured-books-partial.html
@@ -2,5 +2,5 @@
   <a href="{{link}}" tabindex="-1"><img src="{{cover}}" width="125" alt="{{title}}" /></a>
   <h3 id="fb-{{prefix}}-{{id}}-title" class="small-header"><a href="{{link}}">{{title}}</a></h3>
   <p class="description">{{description}}</p>
-  <div class="show"><a href="" aria-labelledby="fb-{{prefix}}-{{id}}-title" data-l10n-id="featured-books-show-more" class="more">Show More</a><a href="" aria-labelledby="fb-{{prefix}}-{{id}}-title" data-l10n-id="featured-books-show-less" class="less">Show Less</a></div>
+  <div class="show-more-less"><a href="" aria-labelledby="fb-{{prefix}}-{{id}}-title" data-l10n-id="featured-books-show-more" class="more">Show More</a><a href="" aria-labelledby="fb-{{prefix}}-{{id}}-title" data-l10n-id="featured-books-show-less" class="less">Show Less</a></div>
 </div>

--- a/src/scripts/modules/featured-books/featured-books.coffee
+++ b/src/scripts/modules/featured-books/featured-books.coffee
@@ -25,9 +25,9 @@ define (require) ->
 
     shaveBookDescriptions: () ->
       shave('.book .description', 60)
-      $('.book:has(.description .js-shave) .show').show()
+      $('.book:has(.description .js-shave) .show-more-less').show()
       toggled_descriptions = $(
-        '.book:has(.description .js-shave):has(.show .less:visible) .description'
+        '.book:has(.description .js-shave):has(.show-more-less .less:visible) .description'
       )
       toggled_descriptions.find('.js-shave-char').hide()
       toggled_descriptions.find('.js-shave').show()
@@ -58,8 +58,8 @@ define (require) ->
       @collection.add(featuredCNXBooks.models)
 
     onAfterRender: () ->
-      $('.show .more').on('click', @readMore)
-      $('.show .less').on('click', @readLess)
+      $('.show-more-less .more').on('click', @readMore)
+      $('.show-more-less .less').on('click', @readLess)
       @shaveBookDescriptionsAfterImagesLoaded()
       $(window).resize(@debouncedShaveBookDescriptionsAfterImagesLoaded)
 

--- a/src/scripts/modules/featured-books/featured-books.less
+++ b/src/scripts/modules/featured-books/featured-books.less
@@ -65,7 +65,7 @@
         overflow: hidden;
       }
 
-      .show {
+      .show-more-less {
         display: none;
         float: right;
 


### PR DESCRIPTION
1) Clicking on a book cover opens in a new browser tab (links have to be relative for webview to do its magic)
2) ‘Show More’ link appears even for books that have no summary (a bootstrap style was colliding with my style named `show`)