### PR TITLE
enable swiping big tables with mouse for desktop users

### DIFF
--- a/src/scripts/helpers/swipe-tables.js
+++ b/src/scripts/helpers/swipe-tables.js
@@ -1,0 +1,46 @@
+if( !/Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent) ) {
+  let tablesToSwipe = Array.prototype.filter.call(document.getElementsByClassName('os-table'), function(el){
+    if (el && (el.offsetWidth < el.getElementsByTagName('table')[0].offsetWidth)) {
+      return el
+    }
+  })
+  
+  if (tablesToSwipe.length > 0) {
+    tablesToSwipe.forEach(function(el){
+      el.classList.add('swipe-table')
+      el.addEventListener('mousedown', function(){
+        startSwiping(el)
+      })
+      el.addEventListener('mouseup', function(){
+        stopSwiping(el)
+      })
+      el.addEventListener('mouseleave', function(){
+        stopSwiping(el)
+      })
+    })
+  }
+  
+  let tableLeftPos, startSwipingPos, swipeRange
+  
+  function handleSwipe (target) {
+    let mouseX = window.event.clientX
+    let swipeDistance = startSwipingPos - mouseX
+    if (swipeDistance <= swipeRange && swipeDistance >= (-1 * swipeRange)) {
+      target.scrollLeft += swipeDistance
+    }
+  }
+  
+  function startSwiping (target) {
+    offsets = target.getBoundingClientRect()
+    tableLeftPos = offsets.left
+    startSwipingPos = window.event.clientX
+    swipeRange = target.getElementsByTagName('table')[0].offsetWidth - target.offsetWidth
+    target.onmousemove = function(e) {
+      handleSwipe(target)
+    }
+  }
+  
+  function stopSwiping (target) {
+    target.onmousemove = function(){}
+  }
+}

--- a/src/scripts/modules/media/body/body.coffee
+++ b/src/scripts/modules/media/body/body.coffee
@@ -199,6 +199,8 @@ define (require) ->
             $el = $(el)
             $el.css('counter-reset', 'list-item ' + $el.attr('start'))
 
+          require(['helpers/swipe-tables'])
+
           # # uncomment to embed fake exercises and see embeddable exercises in action
           # @fakeExercises($temp)
 

--- a/src/scripts/modules/media/body/content-baked.less
+++ b/src/scripts/modules/media/body/content-baked.less
@@ -240,7 +240,17 @@ h1.example-title .text {
 
 // Tables
 // --------------------------------------------------
+.swipe-table {
+  -webkit-touch-callout: none; /* iOS Safari */
+    -webkit-user-select: none; /* Safari */
+     -khtml-user-select: none; /* Konqueror HTML */
+       -moz-user-select: none; /* Firefox */
+        -ms-user-select: none; /* Internet Explorer/Edge */
+            user-select: none; /* Chrome / Opera */
+  cursor: -webkit-grab;
+}
 .os-table {
+  overflow-x: auto;
   margin: @line-height-computed 0;
   .os-table-title {
     text-align: center;


### PR DESCRIPTION
#1739 

How it works:
If user is not on mobile device then script will look for tables which width is greater than their parents widths. In that case script will listen to `mousedown`, `mousemove`, etc. events adn apply proper `target.scrollLeft` value.

@philschatz 
I will ned your help to find the best place to include this script. 

For now it is loading after content is loaded - which is good. But when user will change page by navigating trough menu then script should load one more time. 

Propably it should be import as a function which will be called after page change but I can't find a place for it.