### PR TITLE
issue 1737 set the same margin for os figure inside and outside notes

### DIFF
--- a/src/scripts/modules/media/body/content-baked.less
+++ b/src/scripts/modules/media/body/content-baked.less
@@ -160,7 +160,6 @@ figure:not([data-orient="vertical"]) {
 
   > span[data-type="media"] {
     display: block;
-    margin: 1rem 0;
   }
 }
 .style(example) { .style(note) }


### PR DESCRIPTION
#1737 
`.os-figure` do not have margin top / bottom but they had `margin: 1rem 0;` inside of notes