### PR TITLE
Support scale-down class on media objects

### DIFF
--- a/src/scripts/modules/media/body/content-baked.less
+++ b/src/scripts/modules/media/body/content-baked.less
@@ -371,3 +371,7 @@ h1.example-title .text {
 .appendix [data-type="list"] {
   margin-top: 1rem;
 }
+
+.scale-down > img{
+  width: 60%;
+}

--- a/src/scripts/modules/media/body/content-baked.less
+++ b/src/scripts/modules/media/body/content-baked.less
@@ -372,6 +372,6 @@ h1.example-title .text {
   margin-top: 1rem;
 }
 
-.scale-down > img{
+.scaled-down > img{
   width: 60%;
 }


### PR DESCRIPTION
Scales down images in media objects with class `scale-down` to be 60% of the content width. Link: Issue #1709