### PR TITLE
Fix URL for page extras; Also fix date tests on OS X when day < 10

### DIFF
--- a/src/scripts/models/contents/node.coffee
+++ b/src/scripts/models/contents/node.coffee
@@ -42,9 +42,9 @@ define (require) ->
       id = @getVersionedId()
 
       if @isInBook()
-        return "#{ARCHIVE}/contents/#{@get('book').getVersionedId()}:#{id}.json"
+        return "#{ARCHIVE}/extras/#{@get('book').getVersionedId()}:#{id}"
       else
-        return "#{ARCHIVE}/contents/#{id}.json"
+        return "#{ARCHIVE}/extras/#{id}"
 
     parse: (response, options = {}) ->
       # Don't overwrite the title from the book's table of contents

--- a/test/scripts/helpers/handlebars/date.js
+++ b/test/scripts/helpers/handlebars/date.js
@@ -1,7 +1,7 @@
 describe('handlebar date helper tests', function () {
   'use strict';
   var date, Handlebars, myDate = new Date();
-  var dateRegex = /(\w+)(?:\/|\s)(\d\d)(?:\/|,\s)(\d\d\d\d)/;
+  var dateRegex = /(\w+)(?:\/|\s)(\d{1,2})(?:\/|,\s)(\d\d\d\d)/;
   var months = {
     'January': 0,
     'February': 1,

--- a/test/scripts/models/contents/collection.js
+++ b/test/scripts/models/contents/collection.js
@@ -11,6 +11,6 @@ describe('Collection model', function () {
   it('should use the non-contextual extras url', function () {
     collection.id = 'abcd@1234';
     collection.isInBook().should.equal(false);
-    collection.extrasUrl().should.contain('/contents/' + collection.id);
+    collection.extrasUrl().should.contain('/extras/' + collection.id);
   });
 });

--- a/test/scripts/models/contents/page.js
+++ b/test/scripts/models/contents/page.js
@@ -21,13 +21,13 @@ describe('Page model', function () {
   it('should use the non-contextual extras url if not in a book', function () {
     page.id = 'abcd@1234';
     page.isInBook().should.equal(false);
-    page.extrasUrl().should.contain('/contents/' + page.id);
+    page.extrasUrl().should.contain('/extras/' + page.id);
   });
   it('should use the contextual extras url if in a book', function () {
     book.id = 'abcd@1234';
     page.set('book', book);
     page.id = 'efgh@5678';
     page.isInBook().should.equal(true);
-    page.extrasUrl().should.contain('/contents/' + book.id + ':' + page.id);
+    page.extrasUrl().should.contain('/extras/' + book.id + ':' + page.id);
   });
 });


### PR DESCRIPTION
Oops for the page extras url.

Date tests were always broken on OS X. I fixed them but the fix expected 2 digits, which does not work when the day is less than 10 (it does not prepend a 0).