### PR TITLE
issue 1703 add aria-busy attribute to search view and modify design when searching

### DIFF
--- a/src/scripts/modules/search/search-template.html
+++ b/src/scripts/modules/search/search-template.html
@@ -1,1 +1,1 @@
-<div class="search"></div>
+<div class="search" aria-busy="true"></div>

--- a/src/scripts/modules/search/search-template.html
+++ b/src/scripts/modules/search/search-template.html
@@ -1,1 +1,1 @@
-<div class="search" aria-busy="true"></div>
+<div class="search"></div>

--- a/src/scripts/modules/search/search.coffee
+++ b/src/scripts/modules/search/search.coffee
@@ -31,6 +31,7 @@ define (require) ->
         @regions.search.show(new SearchResultsView({model: @model}))
       else
         @regions.search.show(new AdvancedSearchView())
+      @regions.search.$el[0].setAttribute('aria-busy', 'true')
 
     displayError: () ->
       error = arguments[1] # @model.get('error')

--- a/src/scripts/modules/search/search.coffee
+++ b/src/scripts/modules/search/search.coffee
@@ -21,6 +21,7 @@ define (require) ->
         @model = searchResults.config().load({query: location.search})
 
       @listenTo(@model, 'change:error', @displayError) if @model
+      @listenTo(@model, 'sync', @loaded) if @model
 
     regions:
       search: '.search'
@@ -34,3 +35,7 @@ define (require) ->
     displayError: () ->
       error = arguments[1] # @model.get('error')
       router.appView.render('error', {code: error}) if error
+      @loaded()
+
+    loaded: () ->
+      @regions.search.$el[0].setAttribute('aria-busy', 'false')

--- a/src/scripts/modules/search/search.less
+++ b/src/scripts/modules/search/search.less
@@ -2,4 +2,18 @@
 
 .search {
   margin: 4rem 3rem;
+  .results {
+    > header {
+      margin-top: 1rem;
+    }
+  }
+  &[aria-busy="true"] {
+    .filter {
+      display: none;
+    }
+    .info {
+      float: none !important;
+      margin: auto auto 6rem auto;
+    }
+  }
 }


### PR DESCRIPTION
#1703 
Hide filter column when loading and center progress bar. Also add some `margin-top` for header `Wyniki wyszukwiania` > `Search results`
![loading](https://user-images.githubusercontent.com/31478212/43706995-2c941f6c-9967-11e8-9800-63cfd73f3453.png)
