### PR TITLE
Gzip compressible dist files

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -248,6 +248,18 @@ module.exports = (grunt) ->
           dest: 'dist/images/'
         }]
 
+    # Generate gzip files that will be served by nginx
+    compress:
+      dist:
+        options:
+          mode: 'gzip'
+          level: 9
+        expand: true
+        cwd: 'dist/'
+        src: ['**/*.{html,xml,css,js,map,svg,otf,ttf,ftl}']
+        dest: 'dist/'
+        rename: (dest, src) -> dest + "#{src}.gz"
+
     test:
       options:
         template: 'test/index.template.html'
@@ -313,16 +325,11 @@ module.exports = (grunt) ->
     'uglify:dist'
     'htmlmin:dist'
     'imagemin'
+    'compress:dist'
   ]
 
   # Default
   # -----
   grunt.registerTask 'default', [
-    'requirejs:compile'
-    'copy'
-    'targethtml:dist'
-    'clean'
-    'uglify:dist'
-    'htmlmin:dist'
-    'imagemin'
+    'dist'
   ]

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "grunt-coffeelint": "~0.0.13",
     "grunt-contrib-clean": "~1.1.0",
     "grunt-contrib-copy": "~1.0.0",
+    "grunt-contrib-compress": "~1.4.3",
     "grunt-contrib-htmlmin": "~2.4.0",
     "grunt-contrib-imagemin": "~2.0.1",
     "grunt-contrib-jshint": "~1.1.0",


### PR DESCRIPTION
To be served via the `gzip_static` nginx module. This prevents nginx from having to do work to compress these files every time the page is loaded. Original files are still present. Non-svg images are not compressed because they generally do not compress well. `require.js.map` is too small to compress but unfortunately grunt did not seem to have an easy way to filter files by size.

Goes with https://github.com/Connexions/cnx-deploy/pull/731

Output:

```
Running "compress:dist" (compress) task
Verifying property compress.dist exists in config...OK
Files: dist/fonts/FontAwesome.otf -> dist/fonts/FontAwesome.otf.gz
Files: dist/fonts/fontawesome-webfont.svg -> dist/fonts/fontawesome-webfont.svg.gz
Files: dist/fonts/fontawesome-webfont.ttf -> dist/fonts/fontawesome-webfont.ttf.gz
Files: dist/index.html -> dist/index.html.gz
Files: dist/locale/en-US/dictionary.ftl -> dist/locale/en-US/dictionary.ftl.gz
Files: dist/locale/en-US/images/authoring.svg -> dist/locale/en-US/images/authoring.svg.gz
Files: dist/locale/en-US/images/learning.svg -> dist/locale/en-US/images/learning.svg.gz
Files: dist/locale/pl/dictionary.ftl -> dist/locale/pl/dictionary.ftl.gz
Files: dist/locale/pl/images/authoring.svg -> dist/locale/pl/images/authoring.svg.gz
Files: dist/locale/pl/images/learning.svg -> dist/locale/pl/images/learning.svg.gz
Files: dist/maintenance.html -> dist/maintenance.html.gz
Files: dist/opensearch.xml -> dist/opensearch.xml.gz
Files: dist/scripts/main.js -> dist/scripts/main.js.gz
Files: dist/scripts/main.js.map -> dist/scripts/main.js.map.gz
Files: dist/scripts/require.js -> dist/scripts/require.js.gz
Files: dist/scripts/require.js.map -> dist/scripts/require.js.map.gz
Files: dist/scripts/settings.js -> dist/scripts/settings.js.gz
Files: dist/styles/noscript.css -> dist/styles/noscript.css.gz
Options: archive=null, mode="gzip", createEmptyArchive, level=9
>> Compressed 18 files.
Created dist/fonts/FontAwesome.otf.gz (86567 bytes) - 81% of the original size
Created dist/fonts/fontawesome-webfont.svg.gz (106285 bytes) - 30% of the original size
Created dist/fonts/fontawesome-webfont.ttf.gz (81187 bytes) - 59% of the original size
Created dist/index.html.gz (584 bytes) - 45% of the original size
Created dist/locale/en-US/dictionary.ftl.gz (18705 bytes) - 32% of the original size
Created dist/locale/en-US/images/authoring.svg.gz (4637 bytes) - 37% of the original size
Created dist/locale/en-US/images/learning.svg.gz (7620 bytes) - 40% of the original size
Created dist/locale/pl/dictionary.ftl.gz (21026 bytes) - 33% of the original size
Created dist/locale/pl/images/authoring.svg.gz (8643 bytes) - 31% of the original size
Created dist/locale/pl/images/learning.svg.gz (9904 bytes) - 32% of the original size
Created dist/maintenance.html.gz (539 bytes) - 49% of the original size
Created dist/opensearch.xml.gz (423 bytes) - 56% of the original size
Created dist/scripts/main.js.gz (297251 bytes) - 23% of the original size
Created dist/scripts/main.js.map.gz (785064 bytes) - 23% of the original size
Created dist/scripts/require.js.gz (6552 bytes) - 37% of the original size
Created dist/scripts/require.js.map.gz (93 bytes) - 102% of the original size
Created dist/scripts/settings.js.gz (961 bytes) - 45% of the original size
Created dist/styles/noscript.css.gz (159 bytes) - 68% of the original size
```