### PR TITLE
issue-1814 fix displaying os-figures inside tables

### DIFF
--- a/src/scripts/modules/media/body/content-baked.less
+++ b/src/scripts/modules/media/body/content-baked.less
@@ -303,6 +303,15 @@ h1.example-title .text {
         }
       }
     }
+    .os-figure {
+      margin: 0;
+      img {
+        margin: 0;
+      }
+      .os-caption-container {
+        padding: 1rem 0 0 0;
+      }
+    }
   }
   .os-caption-container {
     font-size: 0.9em;


### PR DESCRIPTION
#1814 
There are 3 points in this issue:
1. Number of table is inside of it.
2. This table in PDF is unnumbered.
3. Headers of the columns and figures inside the tabel are differently aligned.

Only `3` is webview related

This PR is fixing `3` by removing unnecessary margins around figures inside tables and setting padding-top for figure caption because it was overridden by styles for table caption (there is the same class for figure and table caption)

As you can see on screenshot there is wrong html markup for first figure caption (and probaby also for other ones?)
![table](https://user-images.githubusercontent.com/31478212/43888150-1b63f1ca-9bc1-11e8-81e8-62e5e07a789c.png)

