### PR TITLE
Fixed incorrect display of lists

### DIFF
--- a/src/scripts/modules/media/body/content-baked.less
+++ b/src/scripts/modules/media/body/content-baked.less
@@ -210,6 +210,9 @@ h1.example-title .text {
   > :first-child {
     display: inline;
   }
+  > :not(:first-child) {
+    display: block!important;
+  }
 }
 
 // solutions of notes, exercises, and examples have a top-border to separate the solution

--- a/src/scripts/modules/media/body/content-baked.less
+++ b/src/scripts/modules/media/body/content-baked.less
@@ -210,9 +210,6 @@ h1.example-title .text {
   > :first-child {
     display: inline;
   }
-  > :not(:first-child) {
-    display: block!important;
-  }
 }
 
 // solutions of notes, exercises, and examples have a top-border to separate the solution
@@ -374,7 +371,6 @@ h1.example-title .text {
 
 .os-eoc [data-type="exercise"],
 .os-eoc .exercise {
-  p { display: inline; }
   [data-type="problem"] > .number {
     .exercise-number();
   }


### PR DESCRIPTION
Issue : #1777 

I've changed display style of the paragraphs in exercises and solutions:
- the first paragraph displays `inline`, what's making number of the exercise to be inline,
- other elements are display as `block` like in pdf.

### **Before:**
![image](https://user-images.githubusercontent.com/20907906/43890415-fa41e1e0-9bc6-11e8-8b33-873944a0aa6f.png)

### **After:**
![image](https://user-images.githubusercontent.com/20907906/43890422-028a91bc-9bc7-11e8-98db-61f2f05066cf.png)