### PR TITLE
issue 1831 / 1840 / 1843 - no padding left for lists inside tables

### DIFF
--- a/src/scripts/modules/media/body/content-baked.less
+++ b/src/scripts/modules/media/body/content-baked.less
@@ -285,7 +285,8 @@ h1.example-title .text {
         padding: @table-cell-padding;
       }
     }
-    ul {
+    ul, ol{
+      padding-left: 1.5em;
       &[data-bullet-style="none"] {
         padding: 0;
         margin: 0;

--- a/src/scripts/modules/media/body/content-common.less
+++ b/src/scripts/modules/media/body/content-common.less
@@ -346,16 +346,6 @@ table {
   background-color: @table-bg;
   counter-increment: table;
 
-  ul {
-    padding: 0;
-    margin: 0;
-    &[data-bullet-style="none"] {
-      li {
-        list-style: none;
-      }
-    }
-  }
-
   caption {
     margin-top: 0.5rem;
     font-size: 1.3rem;


### PR DESCRIPTION
#1831, #1840 and #1843 

I removed old code from `content-common.less`. It was moved to `content-baked`. I also set padding left for all lists inside tables to be 1.5em

![table](https://user-images.githubusercontent.com/31478212/44263439-40398f00-a21f-11e8-850f-7c98792cebd7.png)
