### PR TITLE
Don't gzip settings.js and require.js.map

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -256,9 +256,9 @@ module.exports = (grunt) ->
           level: 9
         expand: true
         cwd: 'dist/'
-        src: ['**/*.{html,xml,css,js,map,svg,otf,ttf,ftl}']
+        src: ['**/{*.{html,xml,css,svg,otf,ttf,ftl},!(settings).js,!(require.js).map}']
         dest: 'dist/'
-        rename: (dest, src) -> dest + "#{src}.gz"
+        rename: (dest, src) -> "#{dest}#{src}.gz"
 
     test:
       options:


### PR DESCRIPTION
This PR excludes settings.js and require.js.map from being compressed.

settings.js is useless for deployment, because it is templated in Ansible, and devs might want to make local changes and have those be reflected in the local dev server

require.js.map is too small and becomes larger when compressed

Output:

```
Running "compress:dist" (compress) task
Verifying property compress.dist exists in config...OK
Files: dist/fonts/FontAwesome.otf -> dist/fonts/FontAwesome.otf.gz
Files: dist/fonts/fontawesome-webfont.svg -> dist/fonts/fontawesome-webfont.svg.gz
Files: dist/fonts/fontawesome-webfont.ttf -> dist/fonts/fontawesome-webfont.ttf.gz
Files: dist/index.html -> dist/index.html.gz
Files: dist/locale/en-US/dictionary.ftl -> dist/locale/en-US/dictionary.ftl.gz
Files: dist/locale/en-US/images/authoring.svg -> dist/locale/en-US/images/authoring.svg.gz
Files: dist/locale/en-US/images/learning.svg -> dist/locale/en-US/images/learning.svg.gz
Files: dist/locale/pl/dictionary.ftl -> dist/locale/pl/dictionary.ftl.gz
Files: dist/locale/pl/images/authoring.svg -> dist/locale/pl/images/authoring.svg.gz
Files: dist/locale/pl/images/learning.svg -> dist/locale/pl/images/learning.svg.gz
Files: dist/maintenance.html -> dist/maintenance.html.gz
Files: dist/opensearch.xml -> dist/opensearch.xml.gz
Files: dist/scripts/main.js -> dist/scripts/main.js.gz
Files: dist/scripts/main.js.map -> dist/scripts/main.js.map.gz
Files: dist/scripts/require.js -> dist/scripts/require.js.gz
Files: dist/styles/noscript.css -> dist/styles/noscript.css.gz
Options: archive=null, mode="gzip", createEmptyArchive, level=9
>> Compressed 16 files.
Created dist/fonts/FontAwesome.otf.gz (86567 bytes) - 81% of the original size
Created dist/fonts/fontawesome-webfont.svg.gz (106285 bytes) - 30% of the original size
Created dist/fonts/fontawesome-webfont.ttf.gz (81187 bytes) - 59% of the original size
Created dist/index.html.gz (584 bytes) - 45% of the original size
Created dist/locale/en-US/dictionary.ftl.gz (18705 bytes) - 32% of the original size
Created dist/locale/en-US/images/authoring.svg.gz (4637 bytes) - 37% of the original size
Created dist/locale/en-US/images/learning.svg.gz (7620 bytes) - 40% of the original size
Created dist/locale/pl/dictionary.ftl.gz (21026 bytes) - 33% of the original size
Created dist/locale/pl/images/authoring.svg.gz (8643 bytes) - 31% of the original size
Created dist/locale/pl/images/learning.svg.gz (9904 bytes) - 32% of the original size
Created dist/maintenance.html.gz (539 bytes) - 49% of the original size
Created dist/opensearch.xml.gz (423 bytes) - 56% of the original size
Created dist/scripts/main.js.gz (297556 bytes) - 23% of the original size
Created dist/scripts/main.js.map.gz (785357 bytes) - 23% of the original size
Created dist/scripts/require.js.gz (6552 bytes) - 37% of the original size
Created dist/styles/noscript.css.gz (159 bytes) - 68% of the original size
```