### PR TITLE
Small trick to avoid document.write()

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -29,7 +29,7 @@
   </head>
   <body>
     <script>
-      document.write("Loading...")
+      document.getElementsByTagName('body')[0].innerHTML = "Loading...";
     </script>
 
     <noscript>


### PR DESCRIPTION
Avoid `document.write()`. Prevents the console warning and might have performance benefits (probably negligible though) because the browser doesn't have to rebuild the DOM tree.