### PR TITLE
Fixed lists' margin in exercises

### DIFF
--- a/src/scripts/modules/media/body/content-baked.less
+++ b/src/scripts/modules/media/body/content-baked.less
@@ -207,8 +207,11 @@ h1.example-title .text {
 .os-problem-container,
 .os-solution-container {
   display: inline;
-  > :first-child {
+  > :first-child:not(ul):not(ol) {
     display: inline;
+  }
+  > ul, > ol {
+    margin-top: 0rem;
   }
 }
 


### PR DESCRIPTION
Issue #1855, but originally it was created on `cnx-recipes` repo https://github.com/Connexions/cnx-recipes/issues/555.

I've simply changed display style for lists which are direcly below the problem (or solution) number. I've also deleted top margin to those lists in order to reduce the space between the number and first element of the list.

## ***Before:***
![image](https://user-images.githubusercontent.com/20907906/44396373-fa413b80-a53c-11e8-8353-27208f48f68b.png)

## ***After:***
![image](https://user-images.githubusercontent.com/20907906/44396379-ff9e8600-a53c-11e8-9a09-78689f7b7194.png)

## ***PDF:***
![image](https://user-images.githubusercontent.com/20907906/44396382-03320d00-a53d-11e8-8b89-0f37e8f33087.png)