### PR TITLE
fixed numbering and display of exercises

### DIFF
--- a/src/scripts/modules/media/body/content-baked.less
+++ b/src/scripts/modules/media/body/content-baked.less
@@ -204,11 +204,13 @@ h1.example-title .text {
   padding: 0;
 }
 
-.os-problem-container,
-.os-solution-container {
-  display: inline;
-  > :first-child {
+.os-eoc, .os-eob {
+  .os-problem-container,
+  .os-solution-container {
     display: inline;
+    > :first-child {
+      display: inline;
+    }
   }
 }
 

--- a/src/scripts/modules/media/body/content-baked.less
+++ b/src/scripts/modules/media/body/content-baked.less
@@ -210,9 +210,6 @@ h1.example-title .text {
     display: inline;
     > :first-child:not(ul):not(ol) {
       display: inline;
-      > :first-child {
-        display: inline;
-      }
     }
     > ul, > ol {
       margin-top: 0rem;


### PR DESCRIPTION
Numbering fixed in recipes https://github.com/Connexions/cnx-recipes/pull/565 and display is fixed in this PR.
Basically I've changed this commit https://github.com/Connexions/webview/commit/a1f00679b7910be449a2c7dc90b89e4577c5c461 to be more specific (in the `os-eoc` and in the `os-eob`, is that correct @PatBoj ?)