### PR TITLE
add exception for notes to os-problem/solution-container

### DIFF
--- a/src/scripts/modules/media/body/content-baked.less
+++ b/src/scripts/modules/media/body/content-baked.less
@@ -208,11 +208,11 @@ h1.example-title .text {
   .os-problem-container,
   .os-solution-container {
     display: inline;
-    > :first-child:not(ul):not(ol) {
+    > :first-child:not(ul):not(ol):not([data-type="note"]) {
       display: inline;
     }
-    > ul, > ol {
-      margin-top: 0rem;
+    > ul, > ol, [data-type="note"] {
+      margin-top: 0;
     }
   }
 }


### PR DESCRIPTION
#1868 
Do not override display setting for `notes` and set `margin-top: 0` when inside `os-problem/solution-container`
![broken note](https://user-images.githubusercontent.com/31478212/44791630-58f06000-aba2-11e8-9fa9-3cb0e3b0d882.png)
