### PR TITLE
issue 1883 stay at current scroll position after opening history tab

### DIFF
--- a/src/scripts/modules/media/footer/footer.coffee
+++ b/src/scripts/modules/media/footer/footer.coffee
@@ -60,6 +60,8 @@ define (require) ->
     switchTab: ($tab) ->
       if $tab.hasClass('disabled') then return
 
+      beforeY = window.scrollY
+
       $allTabs = @$el.find('.tab')
       $allTabs.addClass('inactive')
       $allTabs.removeClass('active')
@@ -73,3 +75,6 @@ define (require) ->
       else
         @currentTab = null
         $allTabs.removeClass('inactive')
+
+      if window.scrollY != beforeY
+        window.scrollTo(window.scrollX, beforeY)


### PR DESCRIPTION
#1883 
Check if `scrollY` has changed after opening tab and if so then return to starting position.