### PR TITLE
issue 1897 change regex to match also baked books

### DIFF
--- a/src/scripts/models/content.coffee
+++ b/src/scripts/models/content.coffee
@@ -50,7 +50,7 @@ define (require) ->
     defaultPage: ->
       result = 1
       if @isBook() and @isCcap()
-        result += 1 while @getPage(result).get('title').match(/^Preface/)
+        result += 1 while @getPage(result).get('title').match(/Preface/g)
       return result
 
     parse: (response, options = {}) ->

--- a/src/scripts/models/content.coffee
+++ b/src/scripts/models/content.coffee
@@ -50,7 +50,7 @@ define (require) ->
     defaultPage: ->
       result = 1
       if @isBook() and @isCcap()
-        result += 1 while @getPage(result).get('title').match(/Preface/g)
+        result += 1 while @getPage(result).get('title').match(/Preface/)
       return result
 
     parse: (response, options = {}) ->


### PR DESCRIPTION
#1897 
`@getPage(result).get('title')` for `unbaked` books was returning `Preface`
for `baked` books: `<span class="os-text">Preface</span>`

Regex before change: `match(/^Preface/)` `^` is checking if text starts with `Preface`
Regex after change: `match(/Preface/g)` is checking if text contains `Preface`