### PR TITLE
Modify the container to run the 'dist' version of the code

### DIFF
--- a/.jenkins/deploy
+++ b/.jenkins/deploy
@@ -3,7 +3,7 @@ pipeline {
   stages {
     stage('Build') {
       steps {
-        sh "docker build -t openstax/cnx-webview:dev ."
+        sh "docker build --build-arg environment=prod -t openstax/cnx-webview:dev ."
       }
     }
     stage('Publish Dev Container') {

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,11 @@
 FROM openstax/nodejs:6.9.1
 
+# Specify the type of container runtime: 'dev' OR 'prod'
+#  - 'dev' will specify that the container should run the source
+#  - 'prod' will run as close to production as possible
+ARG environment=dev
+ENV ENVIRONMENT=${environment}
+
 # Install higher level packages
 RUN apt-get update -qqy \
   && apt-get -qqy install nginx supervisor
@@ -30,4 +36,4 @@ EXPOSE 8000
 
 USER root
 
-CMD ["supervisord", "-c", "conf/supervisord.dev.conf"]
+CMD supervisord -c conf/supervisord.$ENVIRONMENT.conf

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,7 @@ FROM openstax/nodejs:6.9.1
 
 # Install higher level packages
 RUN apt-get update -qqy \
-  && apt-get -qqy install \
-    nginx \
-    supervisor
+  && apt-get -qqy install nginx supervisor
 
 # Install grunt-cli globally
 RUN npm install -g grunt-cli
@@ -17,12 +15,15 @@ WORKDIR /code
 
 # Copy application code into the image
 COPY . .
+# Remove the local copy of the build distribution directory if it exists
+RUN rm -rf dist
 
 # Execute the following commands as specified user / bower doesn't like being executed as root
 USER webview
 
 # Setup the webview application
 RUN script/setup
+RUN script/build
 
 # Expose default port
 EXPOSE 8000

--- a/conf/nginx.prod.conf
+++ b/conf/nginx.prod.conf
@@ -1,0 +1,91 @@
+error_log   ./nginx.error.log;
+pid         ./nginx.pid;
+
+events { }
+
+http {
+
+  server {
+    listen 8000;
+    root dist;
+    index index.html;
+    try_files $uri /index.html;
+
+    # Use cnx-authoring for login, workspace, POSTing contents and GETting drafts
+    location /login {
+        proxy_pass http://localhost:8080;
+    }
+
+    location /callback {
+        proxy_pass http://localhost:8080;
+    }
+
+    location /logout {
+        proxy_pass http://localhost:8080;
+    }
+
+    location /users/search {
+        proxy_pass http://localhost:8080;
+    }
+
+    # GET the workspace and POST new content
+    location ~ ^/users/contents$ {
+        proxy_pass http://localhost:8080;
+    }
+
+    location /users/profile {
+        proxy_pass http://localhost:8080;
+    }
+
+    location ~ ^/contents/.*@draft\.json {
+        proxy_pass http://localhost:8080;
+    }
+
+    location ~ ^/contents/.*@.*\.json {
+        proxy_pass http://archive.cnx.org;
+    }
+
+    location /extras/ {
+        proxy_pass http://archive.cnx.org;
+    }
+
+    # This deals only with the route `/resources/` (nothing trailing)
+    location ~ ^/resources$ {
+        proxy_pass http://localhost:8080;
+    }
+
+    # Try to fetch resources from archive (most common)
+    # and if they do not exist, fall back to cnx-authoring
+    # from http://linuxplayer.org/2013/06/nginx-try-files-on-multiple-named-location-or-server
+    location ~ ^/resources/.+ {
+        proxy_pass http://archive.cnx.org;
+        proxy_intercept_errors on;
+        recursive_error_pages on;
+        error_page 404 = @cnxauthoring_resources;
+    }
+    location @cnxauthoring_resources  {
+        proxy_pass http://localhost:8080;
+    }
+
+    location ~ ^.*/bower_components/(.*)$ {
+        alias bower_components/$1;
+    }
+
+    location ~ ^.*/data/(.*) {
+        alias test/data/$1;
+    }
+
+    location ~ ^.*/(scripts|styles|images)/(.*) {
+        try_files $uri $uri/ /$1/$2;
+    }
+
+    types {
+        text/html               html htm shtml;
+        text/css                css;
+        image/svg+xml           svg svgz;
+        font/truetype           ttf;
+        font/opentype           otf;
+        application/font-woff   woff;
+    }
+  }
+}

--- a/conf/supervisord.prod.conf
+++ b/conf/supervisord.prod.conf
@@ -1,0 +1,22 @@
+[supervisord]
+nodaemon=true
+logfile=/dev/null
+logfile_maxbytes=0
+loglevel=debug
+
+[program:nginx]
+command=/usr/sbin/nginx -g "daemon off;"
+stdout_events_enabled=true
+stderr_events_enabled=true
+autorestart=true
+redirect_stderr=true
+
+[program:webview]
+username=webview
+directory=/code
+command=/usr/sbin/nginx -p /code -c conf/nginx.prod.conf
+stdout_logfile=/dev/stdout
+stderr_logfile=/dev/stdout
+stdout_events_enabled=true
+stderr_events_enabled=true
+redirect_stderr=true

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -5,5 +5,7 @@ services:
     - ./src:/code/src
     - ./conf:/code/conf
     - ./dist:/code/dist
+    environment:
+    - ENVIRONMENT=dev
     ports:
       - "8000:8000"


### PR DESCRIPTION
This modification helps makes the container look and act more like production.

One can specify which type of runtime they'd like to use the container as by modifying the `ENVIRONMENT` environment variable. The environment can either be 'dev' or 'prod' to indicate whether the container should run in development mode or production mode. Development mode runs nginx from the source code, while the production mode runs from the dist (or built/compiled code).