### PR TITLE
removed paddings from os-number

### DIFF
--- a/src/scripts/modules/media/body/content-baked.less
+++ b/src/scripts/modules/media/body/content-baked.less
@@ -349,12 +349,8 @@ h1.example-title .text {
     font-weight: bold;
   }
   .os-number {
-    padding-right: 4px;
     font-weight: bold;
     text-decoration: none;
-  }
-  .os-number:not(:only-child) {
-    padding: 0;
   }
 
   .group-by .os-index-item {


### PR DESCRIPTION
#1910

According to changes in Connexions/cnx-recipes#613 - I removed the os-number paddings in exercises, so after merging 613 from recipes it will be fixed properly.