### PR TITLE
Don't hash settings.js during build

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -253,7 +253,8 @@ module.exports = (grunt) ->
       dist:
         options:
           # Does not work for locale due to the templated link to dictionary.ftl
-          assets: [ '{fonts,images,scripts,styles}/**/*' ]
+          # Does not work for settings.js because the real settings.js is added later
+          assets: [ '{fonts,images,scripts,styles}/**/!(settings.js)' ]
           baseDir: './dist/'
           separator: '.cache.'
         src: [ 'dist/*.html' ]


### PR DESCRIPTION
This file is added after the build process (by the deployment script), so hashing it during build is not useful. It is also not used because it is loaded in the JS through requirejs and grunt-cache-bust cannot handle that.