### PR TITLE
issue 1905 show links in book descriptions

### DIFF
--- a/src/scripts/models/featured-openstax-book.coffee
+++ b/src/scripts/models/featured-openstax-book.coffee
@@ -11,7 +11,7 @@ define (require) ->
       "&cnx_id=#{@get('cnx_id')}"
 
     parseDescription: (desc) ->
-      if !desc 
+      if !desc
         'This book has no description.'
       else
         desc.replace(/<(?:[^a.]|\s)*?>/g, "")

--- a/src/scripts/models/featured-openstax-book.coffee
+++ b/src/scripts/models/featured-openstax-book.coffee
@@ -10,11 +10,17 @@ define (require) ->
       "&fields=cover_url,description,title,cnx_id" +
       "&cnx_id=#{@get('cnx_id')}"
 
+    parseDescription: (desc) ->
+      if !desc 
+        'This book has no description.'
+      else
+        desc.replace(/<(?:[^a.]|\s)*?>/g, "")
+
     parse: (response, options) ->
       data = if response.items then response.items[0] else response
       parsed =
         title: data?.title
-        description: $(data?.description).text()
+        description: @parseDescription(data?.description)
         cover: data?.cover_url
         type: 'OpenStax Featured'
         id: data?.id.toString()

--- a/src/scripts/modules/featured-books/featured-books-partial.html
+++ b/src/scripts/modules/featured-books/featured-books-partial.html
@@ -1,6 +1,6 @@
 <div class="book">
   <a href="{{link}}" tabindex="-1"><img src="{{cover}}" width="125" alt="{{title}}" /></a>
   <h3 id="fb-{{prefix}}-{{id}}-title" class="small-header"><a href="{{link}}">{{title}}</a></h3>
-  <p class="description">{{description}}</p>
+  <p class="description">{{{description}}}</p>
   <div class="show-more-less"><a href="" aria-labelledby="fb-{{prefix}}-{{id}}-title" data-l10n-id="featured-books-show-more" class="more">Show More</a><a href="" aria-labelledby="fb-{{prefix}}-{{id}}-title" data-l10n-id="featured-books-show-less" class="less">Show Less</a></div>
 </div>

--- a/src/scripts/modules/featured-books/featured-books.coffee
+++ b/src/scripts/modules/featured-books/featured-books.coffee
@@ -7,7 +7,6 @@ define (require) ->
   featuredOpenStaxBooks = require('cs!collections/featured-openstax-books')
   featuredCNXBooks = require('cs!collections/featured-cnx-books')
   imagesLoaded = require('imagesloaded')
-  shave = require('shave')
   template = require('hbs!./featured-books-template')
   require('less!./featured-books')
 
@@ -23,23 +22,10 @@ define (require) ->
       @debouncedShaveBookDescriptionsAfterImagesLoaded = \
         _.debounce(@shaveBookDescriptionsAfterImagesLoaded, 300)
 
-    shaveBookDescriptions: () ->
-      shave('.book .description', 60)
-      $('.book:has(.description .js-shave) .show-more-less').show()
-      toggled_descriptions = $(
-        '.book:has(.description .js-shave):has(.show-more-less .less:visible) .description'
-      )
-      toggled_descriptions.find('.js-shave-char').hide()
-      toggled_descriptions.find('.js-shave').show()
-
-    shaveBookDescriptionsAfterImagesLoaded: () =>
-      imagesLoaded('.books', @shaveBookDescriptions)
-
     readMore: (event) ->
       read_more = $(this).parent()
       book = read_more.parent()
-      book.find('.description .js-shave-char').hide()
-      book.find('.description .js-shave').show('highlight')
+      book.find('.description').css('height', 'auto')
       $(this).hide()
       read_more.find('.less').show()
       event.preventDefault()
@@ -47,8 +33,7 @@ define (require) ->
     readLess: (event) ->
       read_more = $(this).parent()
       book = read_more.parent()
-      book.find('.description .js-shave-char').show('highlight')
-      book.find('.description .js-shave').hide('highlight')
+      book.find('.description').css('height', '60px')
       $(this).hide()
       read_more.find('.more').show()
       event.preventDefault()
@@ -60,7 +45,6 @@ define (require) ->
     onAfterRender: () ->
       $('.show-more-less .more').on('click', @readMore)
       $('.show-more-less .less').on('click', @readLess)
-      @shaveBookDescriptionsAfterImagesLoaded()
       $(window).resize(@debouncedShaveBookDescriptionsAfterImagesLoaded)
 
     onBeforeClose: () ->

--- a/src/scripts/modules/featured-books/featured-books.less
+++ b/src/scripts/modules/featured-books/featured-books.less
@@ -69,10 +69,10 @@
 
       p.description {
         overflow: hidden;
+        height: 60px;
       }
 
       .show-more-less {
-        display: none;
         float: right;
 
         > .more::after {


### PR DESCRIPTION
#1905
There was few problems with this issue:
1. `description: $(data?.description).text()` was converting html description to only text. This is why `<a>` tags were missing - I've created `parseDescription(desc)` to remove all html tags from description except `<a>` tags.
2. `shave` module was converting desc to `text` so again all html tags were gone - I've replaced this module with css rule which is changing height of `.description` to `60px` or `auto` depends on click on `Show more / Show less`.

Now it looks and works the same as before but we are showing `<a>` tags from description.