### PR TITLE
issue 1882 remove border on focus

### DIFF
--- a/src/scripts/modules/media/footer/footer.less
+++ b/src/scripts/modules/media/footer/footer.less
@@ -39,7 +39,8 @@
       }
 
       &:focus {
-        outline: 0;
+        outline: 1px;
+        outline-style: solid;
       }
 
       &.active,

--- a/src/scripts/modules/media/footer/footer.less
+++ b/src/scripts/modules/media/footer/footer.less
@@ -39,9 +39,6 @@
       }
 
       &:focus {
-        border-top: 0.1rem solid @brand-primary;
-        border-left: 0.1rem solid @brand-primary;
-        border-right: 0.1rem solid @brand-primary;
         outline: 0;
       }
 


### PR DESCRIPTION
#1882
There was additional `border` on `:focus` which was causing moving all table. This border is not needed because other elements does not have border so when it's added position of other elements have to be updated.