### PR TITLE
Remove isCcap requirement for pages results - issue #1897

### DIFF
--- a/src/scripts/models/content.coffee
+++ b/src/scripts/models/content.coffee
@@ -49,7 +49,7 @@ define (require) ->
 
     defaultPage: ->
       result = 1
-      if @isBook() and @isCcap()
+      if @isBook()
         result += 1 while @getPage(result).get('title').match(/Preface/)
       return result
 


### PR DESCRIPTION
When clicking on a featured book, the user should land on the first module page on all books.

 issue #1897