### PR TITLE
issue 1947 style figcaption in eoc and eob

### DIFF
--- a/src/scripts/modules/media/body/content-baked.less
+++ b/src/scripts/modules/media/body/content-baked.less
@@ -215,6 +215,12 @@ h1.example-title .text {
       margin-top: 0;
     }
     .os-figure {  margin: 3rem 0; }
+    .ui-has-child-figcaption {
+      figcaption {
+        display: block;
+        text-align: left;
+      }
+    }
   }
 }
 


### PR DESCRIPTION
#1947 

Now figcaption is matching pdf, but I think it will look better if text is centered. What do you think?

![figcaption](https://user-images.githubusercontent.com/31478212/45871890-d9177900-bd8e-11e8-9e98-af6b0dc87835.png)
