### PR TITLE
issue 1757 read solution after open

### DIFF
--- a/src/scripts/modules/media/body/body.coffee
+++ b/src/scripts/modules/media/body/body.coffee
@@ -161,12 +161,11 @@ define (require) ->
 
           # Wrap solutions in a div so "Show/Hide Solutions" work
           $temp.find('.exercise .solution, [data-type="exercise"] [data-type="solution"]')
-          .wrapInner('<section class="ui-body">')
+          .wrapInner('<section class="ui-body" role="alert">')
           .prepend('''
             <div class="ui-toggle-wrapper">
               <button class="btn-link ui-toggle" title="Show/Hide Solution"></button>
             </div>''')
-          .append('<div class="ui-body-live" aria-live="polite"></div>')
 
           $temp.find('figure:has(> figcaption)').addClass('ui-has-child-figcaption')
 
@@ -466,9 +465,7 @@ define (require) ->
       if $solution.hasClass('ui-solution-visible')
         $solution.attr('aria-expanded',true)
         $solution.attr('aria-label',"hide solution")
-        $uiBodyLive.innerHTML = $uiBody.innerHTML
       else
-        $uiBodyLive.innerHTML = ''
         $solution.attr('aria-expanded',false)
         $solution.attr('aria-label',"show solution")
     onEditable: () -> @$el.find('.media-body').addClass('draft')

--- a/src/scripts/modules/media/body/body.coffee
+++ b/src/scripts/modules/media/body/body.coffee
@@ -166,6 +166,7 @@ define (require) ->
             <div class="ui-toggle-wrapper">
               <button class="btn-link ui-toggle" title="Show/Hide Solution"></button>
             </div>''')
+          .append('<div class="ui-body-live" aria-live="polite"></div>')
 
           $temp.find('figure:has(> figcaption)').addClass('ui-has-child-figcaption')
 
@@ -460,10 +461,14 @@ define (require) ->
     toggleSolution: (e) ->
       $solution = $(e.currentTarget).closest('.solution, [data-type="solution"]')
       $solution.toggleClass('ui-solution-visible')
+      $uiBody = $solution[0].getElementsByClassName('ui-body')[0]
+      $uiBodyLive = $solution[0].getElementsByClassName('ui-body-live')[0]
       if $solution.hasClass('ui-solution-visible')
         $solution.attr('aria-expanded',true)
         $solution.attr('aria-label',"hide solution")
+        $uiBodyLive.innerHTML = $uiBody.innerHTML
       else
+        $uiBodyLive.innerHTML = ''
         $solution.attr('aria-expanded',false)
         $solution.attr('aria-label',"show solution")
     onEditable: () -> @$el.find('.media-body').addClass('draft')

--- a/src/scripts/modules/media/body/content-common.less
+++ b/src/scripts/modules/media/body/content-common.less
@@ -280,12 +280,9 @@ blockquote {
       }
     }
 
-    .ui-body {
-      display: none;
-    }
-
     &:not(.ui-solution-visible) {
       > .ui-toggle-wrapper > button.ui-toggle::before { content: '[Show Solution]'; }
+      > section {display:none;}
     }
 
     &.ui-solution-visible {

--- a/src/scripts/modules/media/body/content-common.less
+++ b/src/scripts/modules/media/body/content-common.less
@@ -280,9 +280,12 @@ blockquote {
       }
     }
 
+    .ui-body {
+      display: none;
+    }
+
     &:not(.ui-solution-visible) {
       > .ui-toggle-wrapper > button.ui-toggle::before { content: '[Show Solution]'; }
-      > section { display: none; }
     }
 
     &.ui-solution-visible {


### PR DESCRIPTION
#1757 

To force screen readers to read a text after hiting `Show Solution` we need to have an empty element with `aria-live="polite / assertive"` and content of this element shoud get updated after click.

- To check if this is working go to http://localhost:8000/contents/mwjClAV_@7.1:0KhpF2RH@21/Real-Numbers-Algebra-Essentials
- Start screen reader (Ubuntu - Windows + Alt + S)
- Click before `Show solution` and hit Tab to navigate to button - hit eneter - wait for screen reader to read text