### PR TITLE
replace <br> and </p> tags with spaces

### DIFF
--- a/src/scripts/models/featured-openstax-book.coffee
+++ b/src/scripts/models/featured-openstax-book.coffee
@@ -14,7 +14,7 @@ define (require) ->
       if !desc
         'This book has no description.'
       else
-        desc.replace(/<(?:[^a.]|\s)*?>/g, "")
+        desc.replace(/<\/p>|<br?.>/g, " ").replace(/<(?:[^a.]|\s)*?>/g, "").trim()
 
     parse: (response, options) ->
       data = if response.items then response.items[0] else response


### PR DESCRIPTION
#1964 

Replace end of paragraph (`</p>`) and `<br>` `<br/>` tags with space ` `. Also trim text to avoid double spaces.

Other tags like `<p>` `<span>` etc. are removed at the end.

Input:
`<p>abcd</p><p>1234 <a href="#">link</a><br>ghji</p>`

Output:
`abcd 1234 <a href="#">link</a> ghji`