### PR TITLE
issues 1970 and 1971 - add ellipsis and remove .more button when desc is short enough

### DIFF
--- a/src/scripts/modules/featured-books/featured-books-partial.html
+++ b/src/scripts/modules/featured-books/featured-books-partial.html
@@ -1,6 +1,6 @@
 <div class="book">
   <a href="{{link}}" tabindex="-1"><img src="{{cover}}" width="125" alt="{{title}}" /></a>
   <h3 id="fb-{{prefix}}-{{id}}-title" class="small-header"><a href="{{link}}">{{title}}</a></h3>
-  <p class="description">{{{description}}}</p>
+  <p class="description show-ellipsis">{{{description}}}</p>
   <div class="show-more-less"><a href="" aria-labelledby="fb-{{prefix}}-{{id}}-title" data-l10n-id="featured-books-show-more" class="more">Show More</a><a href="" aria-labelledby="fb-{{prefix}}-{{id}}-title" data-l10n-id="featured-books-show-less" class="less">Show Less</a></div>
 </div>

--- a/src/scripts/modules/featured-books/featured-books.coffee
+++ b/src/scripts/modules/featured-books/featured-books.coffee
@@ -1,5 +1,4 @@
 define (require) ->
-  _ = require('underscore')
   $ = require('jquery')
   require('jqueryui')
   Backbone = require('backbone')
@@ -19,13 +18,11 @@ define (require) ->
       super()
       @listenTo(featuredOpenStaxBooks, 'reset', @render)
       @listenTo(featuredCNXBooks, 'reset', @render)
-      @debouncedShaveBookDescriptionsAfterImagesLoaded = \
-        _.debounce(@shaveBookDescriptionsAfterImagesLoaded, 300)
 
     readMore: (event) ->
       read_more = $(this).parent()
       book = read_more.parent()
-      book.find('.description').css('height', 'auto')
+      book.find('.description').addClass('extended')
       $(this).hide()
       read_more.find('.less').show()
       event.preventDefault()
@@ -33,7 +30,7 @@ define (require) ->
     readLess: (event) ->
       read_more = $(this).parent()
       book = read_more.parent()
-      book.find('.description').css('height', '60px')
+      book.find('.description').removeClass('extended')
       $(this).hide()
       read_more.find('.more').show()
       event.preventDefault()
@@ -45,7 +42,10 @@ define (require) ->
     onAfterRender: () ->
       $('.show-more-less .more').on('click', @readMore)
       $('.show-more-less .less').on('click', @readLess)
-      $(window).resize(@debouncedShaveBookDescriptionsAfterImagesLoaded)
-
-    onBeforeClose: () ->
-      $(window).off('resize', @debouncedShaveBookDescriptionsAfterImagesLoaded)
+      $('.description').each (i, desc) ->
+        $(desc).css('max-height', '100%')
+        if $(desc).height() <= 60
+          $(desc).parent().find('.show-more-less')[0].style.display = 'none'
+          $(desc).removeClass('show-ellipsis')
+        else
+          $(desc).css('max-height', '')

--- a/src/scripts/modules/featured-books/featured-books.less
+++ b/src/scripts/modules/featured-books/featured-books.less
@@ -69,7 +69,33 @@
 
       p.description {
         overflow: hidden;
-        height: 60px;
+        max-height: 60px;
+        text-align: justify;
+      
+        &.extended {
+          max-height: 100%;
+          &.show-ellipsis {
+            &:after {
+              display: none;
+            }
+          }
+        }
+
+        &.show-ellipsis {
+          position: relative;
+          &:after {
+            content: '...';
+            position: absolute;
+            bottom: 0;
+            right: 0;
+            padding-left: 5%;
+            background: -webkit-gradient(linear, left top, right top, from(rgba(255, 255, 255, 0)), to(white), color-stop(50%, white));
+            background: -moz-linear-gradient(to right, rgba(255, 255, 255, 0), white 50%, white);			
+            background: -o-linear-gradient(to right, rgba(255, 255, 255, 0), white 50%, white);
+            background: -ms-linear-gradient(to right, rgba(255, 255, 255, 0), white 50%, white);
+            background: linear-gradient(to right, rgba(255, 255, 255, 0), white 50%, white);
+          }
+        }
       }
 
       .show-more-less {

--- a/src/scripts/modules/featured-books/featured-books.less
+++ b/src/scripts/modules/featured-books/featured-books.less
@@ -84,7 +84,7 @@
         &.show-ellipsis {
           position: relative;
           &:after {
-            content: '...';
+            content: '…';
             position: absolute;
             bottom: 0;
             right: 0;


### PR DESCRIPTION
#1970 #1971 

- remove some shave.js dependencies which are no longer in use
- add ellipsis (...) at the end of the line with some gradient effect
- hide `show more` button when description is short enough

Info: We couldn't use shave.js because this script was removing all html tags and we needed `<a>` tags from description.

![shave](https://user-images.githubusercontent.com/31478212/46612317-77863700-cb10-11e8-8264-d2442a42dd7c.png)
