### PR TITLE
issue 1896 disable overflow-anchor (Google Chrome anchor scrolling)

### DIFF
--- a/src/scripts/pages/app/app.less
+++ b/src/scripts/pages/app/app.less
@@ -1,5 +1,9 @@
 @import "../../../styles/variables.less";
 
+body {
+  overflow-anchor: none;
+}
+
 #header {
   max-width: @max-viewport-width;
   background-color: white;


### PR DESCRIPTION
#1896 

Issue was caused because Google Chrome Anchor Scrolling feature.

At every page change content of `<header id="header">` is rerendered which mean height of this element i jumping from `0` to `x`. When we change page for the first time it tooks longer time to load than next changes which mean view is scrolled before height of header was adjusted, so Google Chrome is trying to fix this with new feature called Anchor Scrolling. 

Fix is simple - disable anchor scrolling. However i'm not sure were should I put this css?