### PR TITLE
Fix functional test execution to filter for stack deployment testing

### DIFF
--- a/.jenkins/deploy
+++ b/.jenkins/deploy
@@ -32,7 +32,7 @@ pipeline {
         // Start the testing container
         sh "docker run -d -v ${WORKSPACE}/xml-report:/xml-report:z --env-file ${WORKSPACE}/env.list --name ${TESTING_CONTAINER_NAME} openstax/cnx-automation:latest"
         // Run the tests
-        sh "docker exec ${TESTING_CONTAINER_NAME} tox -- -m 'webview' --junitxml=/code/report.xml"
+        sh "docker exec ${TESTING_CONTAINER_NAME} tox -- -m 'webview and not (requires_deployment or requires_varnish_routing or legacy)' --junitxml=/code/report.xml"
       }
       post {
         always {


### PR DESCRIPTION
This brings things to a completely successful test run. We're filtering on these markers because the stack deployment at this time because the stack is missing components, which means we aren't able to run all the tests.

![screen shot 2018-10-18 at 11 00 47](https://user-images.githubusercontent.com/168470/47174555-c167dd80-d2c5-11e8-8ff0-a9ea77983f94.png)
