### PR TITLE
Deletes default markers in circled class lists

### DIFF
--- a/src/scripts/modules/media/body/content-baked.less
+++ b/src/scripts/modules/media/body/content-baked.less
@@ -26,6 +26,11 @@ ul, ol {
   margin-top: 1rem;
 }
 
+.circled {
+  list-style-type: none;
+  padding-left: 1rem;
+}
+
 [data-bullet-style="none"] {
   list-style-type: none;
 }


### PR DESCRIPTION
I've deleted default markers from lists with `class="circled"` and I've also changed padding in those elements.

## **Before:**
![image](https://user-images.githubusercontent.com/20907906/47621354-c6633300-daf6-11e8-8344-9140e27cc302.png)

## **After:**
![image](https://user-images.githubusercontent.com/20907906/47621355-c95e2380-daf6-11e8-971d-be34a22e3b9d.png)
