### PR TITLE
issue 2011 center text in all table cells with data-align=center

### DIFF
--- a/src/scripts/modules/media/body/content-baked.less
+++ b/src/scripts/modules/media/body/content-baked.less
@@ -308,12 +308,12 @@ h1.example-title .text {
       td {
         vertical-align: middle;
         padding: @table-cell-padding;
-        &[data-align="center"] {
-          text-align: center;
-        }
       }
       [data-valign="top"] {
         vertical-align: top;
+      }
+      [data-align="center"] {
+        text-align: center;
       }
     }
     ul, ol{


### PR DESCRIPTION
#2011 

`[data-align="center"]` should apply also for `<th>`, not only for `<td>`