### PR TITLE
issue 2004 add responsivity to browser-content

### DIFF
--- a/src/scripts/pages/browse-content/browse-content-template.html
+++ b/src/scripts/pages/browse-content/browse-content-template.html
@@ -5,9 +5,9 @@
   structured into books or course notes, or for other uses. Our open license allows for free
   use and reuse of all our content.</p>
 
-<ul>
+<div class="search-categories">
   {{#each this}}
-    <li>
+    <section class="search-category">
       <h2 class="medium-header">
         <a href="/search?q=subject:&quot;{{name}}&quot;">{{name}}</a>
       </h2>
@@ -18,6 +18,6 @@
         <div data-l10n-id="search-pages" data-l10n-args='{"count":{{count.module}} }'>Pages: {{count.module}}</div>
         <div data-l10n-id="search-books" data-l10n-args='{"count":{{count.collection}} }'>Books: {{count.collection}}</div>
       </div>
-    </li>
+    </section>
   {{/each}}
-</ul>
+</div>

--- a/src/scripts/pages/browse-content/browse-content.less
+++ b/src/scripts/pages/browse-content/browse-content.less
@@ -13,18 +13,15 @@
     margin-bottom: 2rem;
   }
 
-  > ul {
-    .make-row();
-    padding: 0;
+  > .search-categories {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-evenly;
     margin-bottom: 3rem;
-    list-style-type: none;
-    text-align: center;
 
-    > li {
-      .make-lg-column(8);
-      display: inline-block;
-      padding: 2rem 0;
-      width: 33%;
+    > .search-category {
+      width: 250px;
+      margin: 2rem 3rem;
 
       > .medium-header {
         margin-bottom: 1.5rem;


### PR DESCRIPTION
#2004 

add responsivity to `.browser-content`

I've change `ul, li` to `section` because those elements looks more like sections with headers, images and descriptions. I've also used flexbox to postion those elements so there shouldn't be any problems with responsivity.