### PR TITLE
Issue 1999v2

### DIFF
--- a/src/scripts/modules/media/body/body.coffee
+++ b/src/scripts/modules/media/body/body.coffee
@@ -445,6 +445,12 @@ define (require) ->
 
       @regions.about.append(new ContentsView({model: @model, static: true}))
 
+      # Wrap tables inside unbaked books with additional div so we can
+      # apply overflow-x: auto to them. Tables inside baked books are wrapped with .os-table
+      if !@model.asPage().isCollated()
+        $('.main-page table').each (index, table) ->
+          $(table).wrap('<div class="table-wrapper"></div>')
+
     changePage: (e) ->
       # Don't intercept cmd/ctrl-clicks intended to open a link in a new tab
       return if e.metaKey or e.which isnt 1

--- a/src/scripts/modules/media/body/content-common.less
+++ b/src/scripts/modules/media/body/content-common.less
@@ -440,3 +440,10 @@ table {
     margin: 1rem 3rem;
   }
 }
+
+//
+// Equations
+// --------------------------------------------------
+[data-type="equation"] {
+  overflow: auto;
+}

--- a/src/scripts/modules/media/body/content-common.less
+++ b/src/scripts/modules/media/body/content-common.less
@@ -342,6 +342,10 @@ blockquote {
 // Tables
 // --------------------------------------------------
 
+.table-wrapper {
+  overflow-x: auto;
+}
+
 table {
   margin-top: 6rem;
   width: 100%;


### PR DESCRIPTION
#1999

[There were added multiple commits to previous version so I recreated changes on new branch]

overflow: auto; for [data-type="equation"] which makes blockish equations scrollable on smaller screens.

Wrap tables inside unbaked books with additional div so we can apply overflow-x: auto to them which makes them scrollable for devices with smaller screens.