### PR TITLE
issue 1944 rewrite accessibility support for links inside toc

### DIFF
--- a/src/scripts/modules/media/nav/nav.coffee
+++ b/src/scripts/modules/media/nav/nav.coffee
@@ -70,17 +70,14 @@ define (require) ->
       # This component is used in the ToC as well as the intro page.
       # Having the aria attributes causes confusion because there are 2 `<nav>` elements on the page
       # See #1975
-      tocInsideSidebar = $('.toc')[0]
-      if tocInsideSidebar.getAttribute('role')
-        tocInsideSidebar.removeAttribute('role')
-      else
-        tocInsideSidebar.setAttribute('role', 'alert')
+      firstElementInSidebarToc = $('.toc')[0].querySelector('.name-wrapper a, .section-wrapper')
       @tocIsOpen = not @tocIsOpen
       @.trigger('tocIsOpen', @tocIsOpen)
       if @tocIsOpen
         @closeAllContainers() unless @model.get('searchResults')
         for container in @model.get('currentPage')?.containers() ? []
           container.set('expanded', true)
+        firstElementInSidebarToc.focus()
       @updateToc()
 
     toggleBooksList: (e) ->

--- a/src/scripts/modules/media/tabs/contents/contents-template.html
+++ b/src/scripts/modules/media/tabs/contents/contents-template.html
@@ -12,7 +12,7 @@
   {{/if}}
 
   {{#if isBook}}
-    <div class="toc" aria-live="polite">
+    <div class="toc">
       {{! TocView}}
     </div>
 

--- a/src/scripts/modules/media/tabs/contents/toc/section-template.html
+++ b/src/scripts/modules/media/tabs/contents/toc/section-template.html
@@ -15,5 +15,5 @@
       {{~/if~}}
     </div>
   {{/if}}
-  <ul aria-live="polite" {{#if expanded}}data-expanded="true"{{else}}{{#if static}}data-expanded="true"{{/if}}{{/if}}></ul>
+  <ul {{#if expanded}}data-expanded="true"{{else}}{{#if static}}data-expanded="true"{{/if}}{{/if}}></ul>
 {{/if}}

--- a/src/scripts/modules/media/tabs/contents/toc/section.coffee
+++ b/src/scripts/modules/media/tabs/contents/toc/section.coffee
@@ -82,8 +82,13 @@ define (require) ->
       if e.keyCode is 13 or e.keyCode is 32
         e.preventDefault()
         @toggleSection()
-        @$el.find('> div > .section-wrapper').focus()
-        @$el.find('> ul').attr('role', 'alert')
+        isExpanded = @$el.find('button')[0].getAttribute('aria-expanded')
+        if isExpanded is 'true'
+          focusEl = @$el.find('ul')[0].querySelector('.name-wrapper a, .section-wrapper')
+        else
+          focusEl = @$el.find('> div > .section-wrapper')[0]
+
+        focusEl.focus()
 
     removeNode: () ->
       @content.removeNode(@model)


### PR DESCRIPTION
#1944 

[There were added multiple commits to previous version so I recreated changes on new branch]

Previous version worked only in incognito mode and weird things were happening in normal mode.

Changes:
Remove aria-live and role="alert" attributes from .toc and set focus() for closest link or button instead.

In .toc there are: button.section-wrapper for collapsing sections of modules and .name-wrapper a for individual module. I'm selecting first of those two with querySelector which is forcing ChromeVox to read exactly this text.