### PR TITLE
issue 2000 add responsivity rules for metadata when sidebar is open

### DIFF
--- a/src/scripts/modules/media/footer/metadata/metadata.less
+++ b/src/scripts/modules/media/footer/metadata/metadata.less
@@ -95,7 +95,7 @@
 
 }
 
-@media (max-width: @screen-xs-max) {
+.responsive-settings() {
   .media-footer .tab-content {
     overflow: auto;
     .book-page-toggle {
@@ -110,4 +110,14 @@
     margin-left: 0;
     clear: both;
   }
+}
+
+@media (max-width: @screen-md-max) {
+  .sidebar-open {
+    .responsive-settings()
+  }
+}
+
+@media (max-width: @screen-xs-max) {
+  .responsive-settings()
 }


### PR DESCRIPTION
#2000 

When sidebar is open the content is compressed too much even on larger resolutions, so I've added same responsivity rules for this case.