### PR TITLE
issue 2006 move text on splash screen a little bit higher at smaller resolutions

### DIFF
--- a/src/scripts/modules/splash/splash.less
+++ b/src/scripts/modules/splash/splash.less
@@ -71,7 +71,7 @@
         background-color: rgba(255, 255, 255, .2);
         > h1 {
           max-width: 80%;
-          margin: 0;
+          margin: -5rem 0 0 0;
           padding: 0 6rem 3rem 3rem;
           text-shadow: 0 0 .2em rgba(255,255,255,0.8);
         }


### PR DESCRIPTION
#2006 
move text on splash screen a little bit higher at smaller resolutions
![1](https://user-images.githubusercontent.com/31478212/47986199-3f0c5580-e0dc-11e8-90ac-c2467fe5fd82.JPG)
