### PR TITLE
issue 2028 add responsivity to search results filters

### DIFF
--- a/src/scripts/modules/search/results/filter/filter.less
+++ b/src/scripts/modules/search/results/filter/filter.less
@@ -29,11 +29,20 @@
       padding-left: 1.5rem;
       margin: 0.5rem 0;
       width: 100%;
+      display: flex;
+      justify-content: space-between;
 
       > dt {
         text-align: left;
         font-weight: normal;
         white-space: normal;
+        flex: 1 1 50%;
+      }
+
+      > dd {
+        text-align: right;
+        margin: 0;
+        flex: 1 1 50%;
       }
 
       .toggle {


### PR DESCRIPTION
#2028 

`dd` elements (counters next to dates and authors names) had hardcoded style `margin-left: 180px` which was causing overlapping text. I've positioned thoses elements with flexbox so they look the same but doesn't have hardcoded values.

![filters](https://user-images.githubusercontent.com/31478212/48002083-ccff3500-e10a-11e8-9841-52d3e53183e1.png)
