### PR TITLE
Add "Step" before list with "stepwise" calss

### DIFF
--- a/src/scripts/modules/media/body/content-baked.less
+++ b/src/scripts/modules/media/body/content-baked.less
@@ -31,6 +31,16 @@ ul, ol {
   padding-left: 1rem;
 }
 
+.stepwise {
+  list-style-type: none;
+  counter-reset: stepwiseCounter;
+  padding-left: 0;
+  > li:before {
+      content: "Step " counter(stepwiseCounter) ". ";
+      counter-increment: stepwiseCounter;
+  }
+}
+
 [data-bullet-style="none"] {
   list-style-type: none;
 }


### PR DESCRIPTION
Issue #2038 

## **Before:**
![image](https://user-images.githubusercontent.com/20907906/48193992-125e7500-e34c-11e8-8e8f-7f88d4007969.png)

## **After:**
![image](https://user-images.githubusercontent.com/20907906/48193996-18545600-e34c-11e8-91ba-3291b9b41b6b.png)

Those large margins between list elements are caused by this PR https://github.com/Connexions/webview/pull/2041. I mentioned about this in this issue #2031.