### PR TITLE
issue 2006 fix resposivity issue between firefox and chrome for splash text

### DIFF
--- a/src/scripts/modules/splash/splash.less
+++ b/src/scripts/modules/splash/splash.less
@@ -60,19 +60,19 @@
       }
 
       @media (max-width: @grid-float-breakpoint-max) {
-        position: relative;
+        position: absolute;
         top: 0;
-        left: 0;
-        right: 0;
+        right: auto;
         display: flex;
         align-items: center;
         width: 100%;
-        height: calc(@banner-height + @splash-margin-top);
+        height: 100%;
         background-color: rgba(255, 255, 255, .2);
         > h1 {
           max-width: 80%;
-          margin: -5rem 0 0 0;
-          padding: 0 6rem 3rem 3rem;
+          margin: 0;
+          padding-left: 3rem;
+          padding-right: 6rem;
           text-shadow: 0 0 .2em rgba(255,255,255,0.8);
         }
       }


### PR DESCRIPTION
#2006 

It seems like Firefox and Google Chrome were calculating differently position and height of `relative` elements so I've rewrote this part. There are screenshots in issue conversation and you can also check previous version at `qa.cnx.org`.