### PR TITLE
include fonts in the build

### DIFF
--- a/script/build
+++ b/script/build
@@ -4,3 +4,6 @@ source ./script/bootstrap || exit 1
 
 >&2 echo "==> Building dist/"
 npm run-script dist || exit 1
+
+>&2 echo "==> Copying bower_components into dist/ (for fonts)"
+cp -R ./bower_components/ ./dist/


### PR DESCRIPTION
These were not being included in the built package, as seen by the containerized deployments.


Context: https://openstax.slack.com/archives/C0LA54Q5C/p1542224114647800