### PR TITLE
issue 2064 fix for firefox issue with scroll linked effects

### DIFF
--- a/src/scripts/modules/window-with-sidebar/window-with-sidebar.less
+++ b/src/scripts/modules/window-with-sidebar/window-with-sidebar.less
@@ -33,6 +33,7 @@
       width: @sidebar-width;
       height: 100%;
       visibility: visible;
+      position: sticky;
 
       @media (max-width: 640px) {
         width: 100%;


### PR DESCRIPTION
#2064 

This issue was occuring only in firefox because of asynchronus scrolling https://developer.mozilla.org/en-US/docs/Mozilla/Performance/Scroll-linked_effects

It seems to be fixed after adding `position: sticky;` (which mdn mentions in link above) to the `.sidebar` which is container of element which has `position: fixed;`

`position: sticky;` "force" browser to adjust position of this element synchronously. 