### PR TITLE
Delete webview numbering in stepwise lists

### DIFF
--- a/src/scripts/modules/media/body/content-baked.less
+++ b/src/scripts/modules/media/body/content-baked.less
@@ -26,6 +26,11 @@ ul, ol {
   margin-top: 1rem;
 }
 
+.stepwise {
+  list-style-type: none;
+  padding-left: 0;
+}
+
 .circled {
   list-style-type: none;
   padding-left: 1rem;


### PR DESCRIPTION
Continuation of the https://github.com/Connexions/cnx-recipes/issues/704 and it will be working with this PR https://github.com/Connexions/cnx-recipes/pull/718. I've deleted automatic numbering in lists with `class="stepwise"` and changed left padding.

## **Before:**
![image](https://user-images.githubusercontent.com/20907906/48631891-d9fc0e00-e9bf-11e8-97e5-879f9c408863.png)

## **After:**
![image](https://user-images.githubusercontent.com/20907906/48631896-dcf6fe80-e9bf-11e8-8cee-7183914daeb6.png)
