### PR TITLE
issue 2056 do not show clear search icon (x) because it's confusing

### DIFF
--- a/src/scripts/modules/media/nav/nav.coffee
+++ b/src/scripts/modules/media/nav/nav.coffee
@@ -56,7 +56,7 @@ define (require) ->
       'keydown .book-nav a.nav': 'changePageWithKeyboard'
       'click .toggle.btn': 'toggleContents'
       'click .back-to-top > a': 'backToTop'
-      'keydown .searchbar input': 'handleSearchInput'
+      'keyup .searchbar input': 'handleSearchInput'
       'click .searchbar > .clear-search': 'clearSearch'
       'click .searchbar > .fa-search': 'handleSearch'
 
@@ -164,7 +164,7 @@ define (require) ->
 
     enableSearch: ->
       @$el.find('.searchbar > .fa').
-      removeClass('fa-spinner fa-spin load-search').
+      removeClass('fa-times-circle clear-search').
       addClass('fa-search')
 
     handleSearch: ->
@@ -183,12 +183,14 @@ define (require) ->
         if not @tocIsOpen
           @toggleContents()
         @model.set('searchResults', data.results)
-        @enableSearch()
+        @enableClearSearch()
       ).fail((err) ->
         console.error("Search failed:", err)
       )
       
     handleSearchInput: (event) ->
+      if event.target.value == '' && @$el.find('.searchbar > .clear-search').length > 0
+        @enableSearch()
       if event.keyCode == 13
         event.preventDefault()
         @handleSearch()

--- a/src/scripts/modules/media/nav/nav.coffee
+++ b/src/scripts/modules/media/nav/nav.coffee
@@ -162,6 +162,11 @@ define (require) ->
       removeClass('fa-search').
       addClass('fa-spinner fa-spin load-search')
 
+    enableSearch: ->
+      @$el.find('.searchbar > .fa').
+      removeClass('fa-spinner fa-spin load-search').
+      addClass('fa-search')
+
     handleSearch: ->
       @searchTerm = @$el.find('.searchbar input').val()
       if @searchTerm == ''
@@ -178,7 +183,7 @@ define (require) ->
         if not @tocIsOpen
           @toggleContents()
         @model.set('searchResults', data.results)
-        @enableClearSearch()
+        @enableSearch()
       ).fail((err) ->
         console.error("Search failed:", err)
       )


### PR DESCRIPTION
#2056 

Remove `clear search` icon (x) when user manually deleted text in search input.

I've changed `keydown` listener to `keyup` because text is deleted whe key is up and not when key is down. It will not affect other operations like inserting text or hitting enter.
