### PR TITLE
issue 2055 replace visibility:hidden with other css formulas so it's not alocati…

### DIFF
--- a/src/scripts/modules/window-with-sidebar/window-with-sidebar.less
+++ b/src/scripts/modules/window-with-sidebar/window-with-sidebar.less
@@ -50,7 +50,11 @@
     > .main {
       width: ~"calc(100% -" @sidebar-width + @fudge ~")";
       @media (max-width: 640px) {
-        visibility:hidden;
+        position: absolute; 
+        overflow: hidden; 
+        height: 1px; 
+        width: 1px; 
+        margin: -1px;
       }
     }
   }

--- a/src/scripts/modules/window-with-sidebar/window-with-sidebar.less
+++ b/src/scripts/modules/window-with-sidebar/window-with-sidebar.less
@@ -27,6 +27,9 @@
     .transition(~"width" @transition-style);
     width: ~"calc(100% -" @fudge ~")";
     display: inline-block;
+    @media (max-width: 640px) {
+      display: block;
+    }
   }
   &.sidebar-open {
     > .sidebar {
@@ -50,11 +53,7 @@
     > .main {
       width: ~"calc(100% -" @sidebar-width + @fudge ~")";
       @media (max-width: 640px) {
-        position: absolute; 
-        overflow: hidden; 
-        height: 1px; 
-        width: 1px; 
-        margin: -1px;
+        display: none;
       }
     }
   }


### PR DESCRIPTION
…ng space on mobile

#2055 

`visibility: hidden;` is hiding content but it's also allocating space for this content which was why you could scroll empty page. Setting `display: none;` will cause "jumping content" effect so I've used other css trick.