### PR TITLE
issue 2087 apply the same padding to <th> and <td>

### DIFF
--- a/src/scripts/modules/media/body/content-baked.less
+++ b/src/scripts/modules/media/body/content-baked.less
@@ -317,9 +317,11 @@ h1.example-title .text {
       table-layout: fixed;
     }
     tr {
+      td, th {
+        padding: @table-cell-padding;
+      }
       td {
         vertical-align: middle;
-        padding: @table-cell-padding;
       }
       [data-valign="top"] {
         vertical-align: top;


### PR DESCRIPTION
#2087 

apply the same padding to `<th>` and `<td>`

![screenshot_2018-11-23 intermediate algebra - openstax cnx](https://user-images.githubusercontent.com/31478212/48943374-52fce780-ef23-11e8-86af-b3b42f0bcb9d.png)