### PR TITLE
issue 2093 fix for displaing list items for ul, ol with stepwise class

### DIFF
--- a/src/scripts/modules/media/body/content-baked.less
+++ b/src/scripts/modules/media/body/content-baked.less
@@ -29,6 +29,12 @@ ul, ol {
 .stepwise {
   list-style-type: none;
   padding-left: 0;
+  > li {
+    display: flex;
+    .os-stepwise-token {
+      white-space: pre;
+    }
+  }
 }
 
 .circled {


### PR DESCRIPTION
#2093 

@PatBoj This change will require you to wrap everything except token in additional wrapper. Is this doable?
Now its like this:
```
ul.stepwise
  li
    .os-stepwise-token Step 2.
    Some text here
```
I would like it to look like this:
```
ul.stepwise
  li
    .os-stepwise-token Step 2.
    .os-stepwise-content Some text here
```

Because my solution will work until there is list like this:
```
ul.stepwise
  li
    .os-stepwise-token Step 2.
    Some text
    ul Another nested list
    Some text
```
In case like this flexbox will alocate space for 4 columns instead of two


Works for example from issue:
Before:
![screenshot_2018-11-27 intermediate algebra - openstax cnx 1](https://user-images.githubusercontent.com/31478212/49096348-b1e79700-f26a-11e8-9a64-40f0dfa3243f.png)

After:
![screenshot_2018-11-27 intermediate algebra - openstax cnx](https://user-images.githubusercontent.com/31478212/49096347-b1e79700-f26a-11e8-872f-43e632f61049.png)


Not working for another example because text need additional wrapper:
Before:
![screenshot_2018-11-27 intermediate algebra - openstax cnx 3](https://user-images.githubusercontent.com/31478212/49096924-ef98ef80-f26b-11e8-8fe2-f0abc447f871.png)

After:
![screenshot_2018-11-27 intermediate algebra - openstax cnx 2](https://user-images.githubusercontent.com/31478212/49096922-ef98ef80-f26b-11e8-8d2e-1c42c6adf8ac.png)

With additional `.os-stepwise-content` wrapper (I should also remove padding left from nested lists):
![screenshot_2018-11-27 intermediate algebra - openstax cnx 4](https://user-images.githubusercontent.com/31478212/49097026-30910400-f26c-11e8-8fa5-ebd14ecd2c2e.png)


