### PR TITLE
fixed images display in answer key

### DIFF
--- a/src/scripts/modules/media/body/content-baked.less
+++ b/src/scripts/modules/media/body/content-baked.less
@@ -243,6 +243,14 @@ h1.example-title .text {
   }
 }
 
+.os-eob {
+  .os-solution-container {
+    img {
+      display: block;
+    }
+  }
+}
+
 // solutions of notes, exercises, and examples have a top-border to separate the solution
 [data-type="note"],
 [data-type="exercise"],


### PR DESCRIPTION
https://github.com/Connexions/webview/issues/2053
Images in answer-key solutions should now display block instead of inline.

