### PR TITLE
removed paddings from p, ul, ol and .os-table in show solution area

### DIFF
--- a/src/scripts/modules/media/body/content-baked.less
+++ b/src/scripts/modules/media/body/content-baked.less
@@ -258,15 +258,6 @@ h1.example-title .text {
   [data-type="solution"],
   .solution {
     border-top: 0.1rem solid @gray-lighter;
-
-    section p,
-    section ul,
-    section ol,
-    section .os-table {
-      padding-left: 1.5rem;
-      padding-right: 1.5rem;
-    }
-
   }
 }
 


### PR DESCRIPTION
https://github.com/Connexions/webview/issues/2097

After removing paddings of `p`, `ul`, `ol` and `.os-table` the solutions for Examples look fine to me.
I'm not sure if that should be removed only for `examples` or also as is now for `notes` and `exercises`?
