### PR TITLE
need the | for continuation lines

### DIFF
--- a/src/locale/en-US/dictionary.ftl
+++ b/src/locale/en-US/dictionary.ftl
@@ -240,7 +240,7 @@ search-header = Welcome to the OpenStax CNX Library
 search-content =
   | The content in OpenStax CNX comes in two formats:
   | <strong>Pages</strong>, which are like
-    small "knowledge chunks,"
+  |  small "knowledge chunks,"
   | and <strong>Books</strong>, which are groups of Pages.
   | Our open license allows for free use and reuse of all our content.
 


### PR DESCRIPTION
Seems the ftl format is very fragile, and if you break it, all the translations break.

I see a completely _missing_ "get this book" button with the broken FTL, as opposed to the broken styling of that button for devb. You can verify that this is a l20n.js problem noticing that 1. the menu entries at the top of the page are missing, and 2. change browser language to Polish, and everything is fixed. In the console, there's traceback from l20n.js 

With this fix, everything works