### PR TITLE
Remove all styling for .stepwise lists

### DIFF
--- a/src/scripts/modules/media/body/content-baked.less
+++ b/src/scripts/modules/media/body/content-baked.less
@@ -27,10 +27,7 @@ ul, ol {
 }
 
 .stepwise {
-  list-style-type: none;
-  padding-left: 0;
   > li {
-    display: flex;
     .os-stepwise-token {
       white-space: pre;
     }

--- a/src/scripts/modules/media/body/content-baked.less
+++ b/src/scripts/modules/media/body/content-baked.less
@@ -26,19 +26,6 @@ ul, ol {
   margin-top: 1rem;
 }
 
-.stepwise {
-  > li {
-    .os-stepwise-token {
-      white-space: pre;
-    }
-    .os-stepwise-content {
-      > ul, ol {
-        padding-left: 1rem;
-      }
-    }
-  }
-}
-
 .circled {
   list-style-type: none;
   padding-left: 1rem;


### PR DESCRIPTION
#2127 

Remove all styling for `.stepwise` lists until recipies part will be applied to all books.
See #2095 for details