### PR TITLE
Style .os-stepwise

### DIFF
--- a/src/scripts/modules/media/body/content-baked.less
+++ b/src/scripts/modules/media/body/content-baked.less
@@ -26,6 +26,22 @@ ul, ol {
   margin-top: 1rem;
 }
 
+.os-stepwise {
+  list-style-type: none;
+  padding-left: 0;
+  > li {
+    display: flex;
+    .os-stepwise-token {
+      white-space: pre;
+    }
+    .os-stepwise-content {
+      > ul, ol {
+        padding-left: 1rem;
+      }
+    }
+  }
+}
+
 .circled {
   list-style-type: none;
   padding-left: 1rem;


### PR DESCRIPTION
@PatBoj pr https://github.com/Connexions/cnx-recipes/pull/750 was merged so now we can apply styles for `.os-stepwise`

This style was removed due to style breaking in books which wasn't baked with proper recipies / feature flag (https://github.com/Connexions/webview/pull/2138)