### PR TITLE
Fixed event issue

### DIFF
--- a/src/scripts/modules/media/footer/downloads/downloads.coffee
+++ b/src/scripts/modules/media/footer/downloads/downloads.coffee
@@ -7,16 +7,19 @@ define (require) ->
   return class DownloadsView extends FooterTabView
     template: template
 
-    events:
+    parentEvents = FooterTabView.prototype.events
+    _.extend({}, parentEvents,
       'click [data-format="PDF"]': (e) ->
         analytics.sendDownloadAnalytics(@model.get('googleAnalytics'),@model.attributes.title, 'PDF', \
         @model.attributes.downloads[0].path)
+        return true
       'click [data-format="EPUB"]': (e) ->
         analytics.sendDownloadAnalytics(@model.get('googleAnalytics'),@model.attributes.title, 'EPUB', \
         @model.attributes.downloads[1].path)
       'click [data-format="Offline ZIP"]': (e) ->
         analytics.sendDownloadAnalytics(@model.get('googleAnalytics'),@model.attributes.title, 'Offline Zip', \
         @model.attributes.downloads[2].path)
+    )
 
     initialize: () ->
       super()


### PR DESCRIPTION
Events added for Google Analytics were preventing the events of the download tab parent object from firing when the button was clicked. The fix was to combine all the events. Many thanks to Roy for the path to the fix.